### PR TITLE
Improve restore process and link handling

### DIFF
--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/pipeline/BaseBackupPipeline.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/pipeline/BaseBackupPipeline.java
@@ -154,7 +154,7 @@ public class BaseBackupPipeline<T extends BarjCargoArchiverFileOutputStream> imp
         archivedFileMetadata.setArchivedHash(source.getContentBoundary().getArchivedHash());
         if (!Objects.equals(archivedFileMetadata.getOriginalHash(), fileMetadata.getOriginalHash())) {
             log.warn("The hash changed between delta calculation and archival for: " + fileMetadata.getAbsolutePath()
-                    + "The archive might contain corrupt data for the file.");
+                    + " The archive might contain corrupt data for the file.");
         }
         //commit
         fileMetadata.setArchiveMetadataId(archivedFileMetadata.getId());

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/pipeline/ParallelBackupPipeline.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/pipeline/ParallelBackupPipeline.java
@@ -105,7 +105,7 @@ public class ParallelBackupPipeline extends BaseBackupPipeline<ParallelBarjCargo
             archivedFileMetadata.setArchivedHash(boundarySource.getContentBoundary().getArchivedHash());
             if (!Objects.equals(archivedFileMetadata.getOriginalHash(), fileMetadata.getOriginalHash())) {
                 log.warn("The hash changed between delta calculation and archival for: " + fileMetadata.getAbsolutePath()
-                        + "The archive might contain corrupt data for the file.");
+                        + " The archive might contain corrupt data for the file.");
             }
             //commit
             fileMetadata.setArchiveMetadataId(archivedFileMetadata.getId());

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/ManifestManagerImpl.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/ManifestManagerImpl.java
@@ -188,7 +188,7 @@ public class ManifestManagerImpl implements ManifestManager {
                     remainingFiles.entrySet().stream()
                             .filter(entry -> manifest.getVersions().contains(entry.getValue().getBackupIncrement()))
                             .forEach(entry -> {
-                                //use the file metadata form the last manifest as that is the source of truth
+                                //use the file metadata from the last manifest as that is the source of truth
                                 files.computeIfAbsent(manifest.getFileNamePrefix(), prefix -> new HashMap<>())
                                         .put(entry.getKey().getId(), entry.getKey());
                                 //find the archived entry in the earlier manifests to be able to add the file name prefix

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/model/enums/FileType.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/model/enums/FileType.java
@@ -36,7 +36,7 @@ public enum FileType {
      */
     SYMBOLIC_LINK(BasicFileAttributes::isSymbolicLink, true) {
         public InputStream streamContent(final Path path) throws IOException {
-            final var linkedPathAsString = Files.readSymbolicLink(path).toAbsolutePath().toString();
+            final var linkedPathAsString = Files.readSymbolicLink(path).toString();
             return new ByteArrayInputStream(linkedPathAsString.getBytes(StandardCharsets.UTF_8));
         }
     },

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestoreController.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestoreController.java
@@ -59,13 +59,14 @@ public class RestoreController {
         final var manifests = manifestManager.load(backupDirectory, fileNamePrefix, kek, Integer.MAX_VALUE);
         log.info("Merging {} manifests", manifests.size());
         manifest = manifestManager.mergeForRestore(manifests);
+        log.info("Merge completed. Found {} files in backup.", manifest.allFilesReadOnly().size());
         filesFound = new HashMap<>();
         allEntries = new ArrayList<>();
+        final var archivedEntries = manifest.allArchivedEntriesReadOnly();
         manifest.allFilesReadOnly().values().stream()
                 .filter(metadata -> metadata.getStatus() != Change.DELETED)
                 .forEach(metadata -> {
                     if (metadata.getFileType() != FileType.DIRECTORY) {
-                        final var archivedEntries = manifest.allArchivedEntriesReadOnly();
                         final var archived = archivedEntries.get(metadata.getArchiveMetadataId());
                         filesFound.put(metadata, archived);
                     }


### PR DESCRIPTION
__Issue:__ #84

### Description
<!-- A short summary of changes -->

- Updates backup process to save symbolic link values as-is (no longer force absolute paths)
- Updates restore process to avoid a wasteful recalculation of some file sets
- Adds additional logs to make it more clear what is happening during backup and restore
- Fixes some typos
- Changes how exists checks are done in case of symbolic links (links are no longer followed) to avoid collisions

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

- Changes link handling in backups. It is recommended to create new full backups after the change.
<!-- Any additional remarks you may have. -->
