### PR TITLE
Bug: Restoring on Windows throws an exception

### DIFF
--- a/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/Main.java
+++ b/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/Main.java
@@ -14,8 +14,22 @@ public class Main {
      *
      * @param args the command line arguments
      */
-    public static void main(final String[] args) throws Exception {
-        final var controller = new Controller(args, System.console());
-        controller.run();
+    public static void main(final String[] args) {
+        new Main().execute(args);
     }
+
+    void execute(final String[] args) {
+        try {
+            final var controller = new Controller(args, System.console());
+            controller.run();
+        } catch (final Exception e) {
+            log.error("Execution failed: ", e);
+            exitWithError();
+        }
+    }
+
+    void exitWithError() {
+        System.exit(1);
+    }
+
 }

--- a/file-barj-job/src/main/resources/logback.xml
+++ b/file-barj-job/src/main/resources/logback.xml
@@ -1,12 +1,17 @@
 <configuration>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>file-barj.log</file>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{3}</pattern>
+        </encoder>
+    </appender>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{3}</pattern>
         </encoder>
     </appender>
     <root level="INFO">
+        <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/file-barj-job/src/test/java/com/github/nagyesta/filebarj/job/MainTest.java
+++ b/file-barj-job/src/test/java/com/github/nagyesta/filebarj/job/MainTest.java
@@ -3,15 +3,21 @@ package com.github.nagyesta.filebarj.job;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.mockito.Mockito.*;
+
 class MainTest {
 
     @Test
-    void testMainShouldThrowExceptionWhenUnknownTaskSelected() {
+    void testMainShouldNotThrowExceptionWhenUnknownTaskSelected() {
         //given
+        final var args = new String[] {};
+        final var underTest = spy(new Main());
+        doNothing().when(underTest).exitWithError();
 
         //when
-        Assertions.assertThrows(IllegalArgumentException.class, () -> Main.main(new String[0]));
+        Assertions.assertDoesNotThrow(() -> underTest.execute(args));
 
-        //then + exception
+        //then
+        verify(underTest).exitWithError();
     }
 }

--- a/file-barj-job/src/test/resources/logback-test.xml
+++ b/file-barj-job/src/test/resources/logback-test.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{3}</pattern>
+        </encoder>
+    </appender>
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
__Issue:__ #93

### Description
<!-- A short summary of changes -->

- Fixes path verification code to always use UNIX paths for paths inside the archive
- Fixes logging approach to only log a few examples of the corrupt paths in case invalid entries are found
- Adds file based logger to keep logs for the future
- Makes sure that uncaught exceptions are caught and logged in the Main class

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
