### PR TITLE
Implement duplicate handling strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ File BaRJ comes with the following features
 - Backup archive splitting to configurable chunks
 - Backup archive integrity checks
 - Restore/unpack previous backup
+- Duplicate handling (storing duplicates of the same file only once)
 
 ### Planned features
 
-- Duplicate handling (storing duplicates of the same file only once)
 - Merge previous backup increments
 - UI for convenient configuration
 

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/pipeline/ParallelBackupPipeline.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/pipeline/ParallelBackupPipeline.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
@@ -55,21 +54,30 @@ public class ParallelBackupPipeline extends BaseBackupPipeline<ParallelBarjCargo
     /**
      * Stores the given files in the archive.
      *
-     * @param fileMetadataList The list of file metadata we should store
+     * @param groupedFileMetadataList The list of file metadata we should store
      * @return the list of archived files
      * @throws ArchivalException When the file cannot be archived due to an I/O error from the stream
      */
     public List<ArchivedFileMetadata> storeEntries(
-            @NonNull final List<FileMetadata> fileMetadataList) throws ArchivalException {
-        final var list = fileMetadataList.stream().map(fileMetadata -> {
-            if (fileMetadata == null) {
-                throw new IllegalArgumentException("File metadata cannot be null");
+            @NonNull final List<List<FileMetadata>> groupedFileMetadataList) throws ArchivalException {
+        final var list = groupedFileMetadataList.stream().map(fileMetadataList -> {
+            if (fileMetadataList == null || fileMetadataList.isEmpty()) {
+                throw new IllegalArgumentException("File metadata list cannot be null or empty");
             }
+            final var fileMetadata = fileMetadataList.get(0);
             try {
                 log.debug("Storing {}", fileMetadata.getAbsolutePath());
                 fileMetadata.assertContentSource();
                 final var archivedFileMetadata = generateArchiveFileMetadata(fileMetadata);
-                return archiveContentAndUpdateMetadata(fileMetadata, archivedFileMetadata);
+                return archiveContentAndUpdateMetadata(fileMetadata, archivedFileMetadata)
+                        .thenApply(archived -> {
+                            fileMetadataList.stream().skip(1).forEach(duplicate -> {
+                                warnIfHashDoesNotMatch(duplicate, archived);
+                                duplicate.setArchiveMetadataId(archived.getId());
+                                archived.getFiles().add(duplicate.getId());
+                            });
+                            return archived;
+                        });
             } catch (final Exception e) {
                 log.error("Failed to store {}", fileMetadata.getAbsolutePath(), e);
                 throw new ArchivalException("Failed to store " + fileMetadata.getAbsolutePath(), e);
@@ -103,10 +111,7 @@ public class ParallelBackupPipeline extends BaseBackupPipeline<ParallelBarjCargo
         return futureSource.thenApplyAsync(boundarySource -> {
             archivedFileMetadata.setOriginalHash(boundarySource.getContentBoundary().getOriginalHash());
             archivedFileMetadata.setArchivedHash(boundarySource.getContentBoundary().getArchivedHash());
-            if (!Objects.equals(archivedFileMetadata.getOriginalHash(), fileMetadata.getOriginalHash())) {
-                log.warn("The hash changed between delta calculation and archival for: " + fileMetadata.getAbsolutePath()
-                        + " The archive might contain corrupt data for the file.");
-            }
+            warnIfHashDoesNotMatch(fileMetadata, archivedFileMetadata);
             //commit
             fileMetadata.setArchiveMetadataId(archivedFileMetadata.getId());
             return archivedFileMetadata;

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/worker/BackupScopePartitioner.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/worker/BackupScopePartitioner.java
@@ -1,0 +1,22 @@
+package com.github.nagyesta.filebarj.core.backup.worker;
+
+import com.github.nagyesta.filebarj.core.model.FileMetadata;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Partitions the backup scope into smaller batches.
+ */
+public interface BackupScopePartitioner {
+
+    /**
+     * Partitions the backup scope into smaller batches.
+     *
+     * @param scope the backup scope
+     * @return the partitioned scope
+     */
+    @NotNull
+    List<List<List<FileMetadata>>> partitionBackupScope(@NotNull Collection<FileMetadata> scope);
+}

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/worker/DefaultBackupScopePartitioner.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/worker/DefaultBackupScopePartitioner.java
@@ -1,0 +1,73 @@
+package com.github.nagyesta.filebarj.core.backup.worker;
+
+import com.github.nagyesta.filebarj.core.config.enums.DuplicateHandlingStrategy;
+import com.github.nagyesta.filebarj.core.config.enums.HashAlgorithm;
+import com.github.nagyesta.filebarj.core.model.FileMetadata;
+import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Base implementation of {@link BackupScopePartitioner}.
+ */
+public class DefaultBackupScopePartitioner implements BackupScopePartitioner {
+
+    private final int batchSize;
+    private final Function<FileMetadata, String> groupingFunction;
+
+    /**
+     * Creates a new instance with the specified batch size.
+     *
+     * @param batchSize                 the batch size
+     * @param duplicateHandlingStrategy the duplicate handling strategy
+     * @param hashAlgorithm             the hash algorithm the backup is using
+     */
+    public DefaultBackupScopePartitioner(
+            final int batchSize,
+            @NonNull final DuplicateHandlingStrategy duplicateHandlingStrategy,
+            @NonNull final HashAlgorithm hashAlgorithm) {
+        this.batchSize = batchSize;
+        this.groupingFunction = duplicateHandlingStrategy.fileGroupingFunctionForHash(hashAlgorithm);
+    }
+
+    @Override
+    @NotNull
+    public List<List<List<FileMetadata>>> partitionBackupScope(@NonNull final Collection<FileMetadata> scope) {
+        final var groupedScope = filterAndGroup(scope);
+        return partition(groupedScope);
+    }
+
+    @NotNull
+    private Collection<List<FileMetadata>> filterAndGroup(@NotNull final Collection<FileMetadata> scope) {
+        return scope.stream()
+                .filter(metadata -> metadata.getStatus().isStoreContent())
+                .filter(metadata -> metadata.getFileType().isContentSource())
+                .collect(Collectors.groupingBy(groupingFunction))
+                .values();
+    }
+
+    @NotNull
+    private List<List<List<FileMetadata>>> partition(@NotNull final Collection<List<FileMetadata>> groupedScope) {
+        final List<List<List<FileMetadata>>> partitionedScope = new ArrayList<>();
+        var batch = new ArrayList<List<FileMetadata>>();
+        var size = 0;
+        for (final var group : groupedScope) {
+            batch.add(group);
+            size += group.size();
+            if (size >= batchSize) {
+                partitionedScope.add(batch);
+                batch = new ArrayList<>();
+                size = 0;
+            }
+        }
+        if (!batch.isEmpty()) {
+            partitionedScope.add(batch);
+        }
+        return partitionedScope;
+    }
+}

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/enums/DuplicateHandlingStrategy.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/enums/DuplicateHandlingStrategy.java
@@ -1,5 +1,10 @@
 package com.github.nagyesta.filebarj.core.config.enums;
 
+import com.github.nagyesta.filebarj.core.model.FileMetadata;
+import lombok.NonNull;
+
+import java.util.function.Function;
+
 /**
  * Defines the strategy used in case a file is found in more than one place.
  */
@@ -11,18 +16,28 @@ public enum DuplicateHandlingStrategy {
      */
     KEEP_EACH,
     /**
-     * Archives one copy for each backup increment.
-     * <br/>e.g.,<br/>
-     * The second instance of the same file is not added to the current backup increment if it was
-     * already saved once. Each duplicate can point to the same archive file.
-     */
-    KEEP_ONE_PER_INCREMENT,
-    /**
      * Archives one copy per any increment of the backup since the last full backup.
      * <br/>e.g.,<br/>
      * The file is not added to the current archive even if the duplicate is found archived in a
      * previous backup version, such as a file was overwritten with a previously archived version
      * of the same file,
      */
-    KEEP_ONE_PER_BACKUP
+    KEEP_ONE_PER_BACKUP {
+
+        @Override
+        public Function<FileMetadata, String> fileGroupingFunctionForHash(final @NonNull HashAlgorithm hashAlgorithm) {
+            return hashAlgorithm.fileGroupingFunction();
+        }
+    };
+
+    /**
+     * Returns the file metadata grouping function for the specified hash algorithm. The grouping
+     * function is used to form groups containing the files with the same content in the backup.
+     *
+     * @param hashAlgorithm the hash algorithm
+     * @return the grouping function
+     */
+    public Function<FileMetadata, String> fileGroupingFunctionForHash(@NonNull final HashAlgorithm hashAlgorithm) {
+        return fileMetadata -> fileMetadata.getId().toString();
+    }
 }

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/enums/HashAlgorithm.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/enums/HashAlgorithm.java
@@ -1,10 +1,12 @@
 package com.github.nagyesta.filebarj.core.config.enums;
 
+import com.github.nagyesta.filebarj.core.model.FileMetadata;
 import com.github.nagyesta.filebarj.io.stream.internal.OptionalDigestOutputStream;
 import lombok.Getter;
 import lombok.ToString;
 
 import java.io.OutputStream;
+import java.util.function.Function;
 
 /**
  * Defines the supported hash algorithms used for hash calculations.
@@ -12,10 +14,18 @@ import java.io.OutputStream;
 @Getter
 @ToString
 public enum HashAlgorithm {
+
     /**
      * No hash calculation needed.
      */
-    NONE(null),
+    NONE(null) {
+        @Override
+        public Function<FileMetadata, String> fileGroupingFunction() {
+            return fileMetadata -> fileMetadata.getAbsolutePath().getFileName().toString()
+                    + SEPARATOR + fileMetadata.getOriginalSizeBytes()
+                    + SEPARATOR + fileMetadata.getLastModifiedUtcEpochSeconds();
+        }
+    },
     /**
      * MD5.
      */
@@ -32,6 +42,8 @@ public enum HashAlgorithm {
      * SHA-512.
      */
     SHA512("SHA-512");
+
+    private static final String SEPARATOR = "_";
 
     private final String algorithmName;
 
@@ -53,5 +65,15 @@ public enum HashAlgorithm {
      */
     public OptionalDigestOutputStream decorate(final OutputStream stream) {
         return new OptionalDigestOutputStream(stream, this.getAlgorithmName());
+    }
+
+    /**
+     * Returns the file metadata grouping function for the hash algorithm.
+     *
+     * @return the grouping function
+     */
+    public Function<FileMetadata, String> fileGroupingFunction() {
+        return fileMetadata -> fileMetadata.getOriginalHash()
+                + SEPARATOR + fileMetadata.getOriginalSizeBytes();
     }
 }

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestorePipeline.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestorePipeline.java
@@ -111,6 +111,10 @@ public class RestorePipeline {
                 .map(FileMetadata::getAbsolutePath)
                 .collect(Collectors.toSet());
         final var files = manifest.getFilesOfLastManifest();
+        files.values().stream()
+                .filter(fileMetadata -> fileMetadata.getError() != null)
+                .forEach(fileMetadata -> log.warn("File {} might be corrupted. The following error was saved during backup:\n  {}",
+                        fileMetadata.getAbsolutePath(), fileMetadata.getError()));
         final var entries = manifest.getArchivedEntriesOfLastManifest();
         final var restoreScope = new RestoreScope(files, entries, changeStatus, pathsToRestore);
         final var filesWithContentChanges = restoreScope.getChangedContentSourcesByPath();

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/backup/pipeline/ParallelBackupPipelineTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/backup/pipeline/ParallelBackupPipelineTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 class ParallelBackupPipelineTest extends TempFileAwareTest {
@@ -50,8 +51,23 @@ class ParallelBackupPipelineTest extends TempFileAwareTest {
         //given
         final var manifest = getManifest();
         final var underTest = new ParallelBackupPipeline(manifest, 1);
-        final var list = new ArrayList<FileMetadata>();
+        final var list = new ArrayList<List<FileMetadata>>();
         list.add(null);
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.storeEntries(list));
+
+        //then + exception
+    }
+
+    @SuppressWarnings({"resource"})
+    @Test
+    void testStoreEntriesShouldThrowExceptionWhenCalledWithAnEmptyListEntryInTheList() throws IOException {
+        //given
+        final var manifest = getManifest();
+        final var underTest = new ParallelBackupPipeline(manifest, 1);
+        final var list = new ArrayList<List<FileMetadata>>();
+        list.add(List.of());
 
         //when
         Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.storeEntries(list));

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/backup/worker/DefaultBackupScopePartitionerTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/backup/worker/DefaultBackupScopePartitionerTest.java
@@ -1,0 +1,107 @@
+package com.github.nagyesta.filebarj.core.backup.worker;
+
+import com.github.nagyesta.filebarj.core.TempFileAwareTest;
+import com.github.nagyesta.filebarj.core.config.enums.DuplicateHandlingStrategy;
+import com.github.nagyesta.filebarj.core.config.enums.HashAlgorithm;
+import com.github.nagyesta.filebarj.core.model.FileMetadata;
+import com.github.nagyesta.filebarj.core.model.enums.Change;
+import com.github.nagyesta.filebarj.core.model.enums.FileType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+class DefaultBackupScopePartitionerTest extends TempFileAwareTest {
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalledWithNullDuplicateHandlingStrategy() {
+        //given
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new DefaultBackupScopePartitioner(1, null, HashAlgorithm.NONE));
+
+        //then + exception
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalledWithNullHashAlgorithm() {
+        //given
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new DefaultBackupScopePartitioner(1, DuplicateHandlingStrategy.KEEP_EACH, null));
+
+        //then + exception
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testPartitionBackupScopeShouldThrowExceptionWhenCalledWithNull() {
+        //given
+        final var partitioner = new DefaultBackupScopePartitioner(1, DuplicateHandlingStrategy.KEEP_EACH, HashAlgorithm.NONE);
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> partitioner.partitionBackupScope(null));
+
+        //then + exception
+    }
+
+    @Test
+    void testPartitionBackupScopeShouldReturnEmptyListWhenCalledWithEmptyList() {
+        //given
+        final var partitioner = new DefaultBackupScopePartitioner(1, DuplicateHandlingStrategy.KEEP_EACH, HashAlgorithm.NONE);
+
+        //when
+        final var actual = partitioner.partitionBackupScope(Collections.emptyList());
+
+        //then
+        Assertions.assertEquals(List.of(), actual);
+    }
+
+    @Test
+    void testPartitionBackupScopeShouldReturnPartitionsWhenCalledWhileUsingKeepOnePerBackupStrategy() {
+        //given
+        final var partitioner = new DefaultBackupScopePartitioner(1, DuplicateHandlingStrategy.KEEP_ONE_PER_BACKUP, HashAlgorithm.SHA256);
+        final var fileA1 = getFileMetadata("hash-a");
+        final var fileA2 = getFileMetadata("hash-a");
+        final var fileA3 = getFileMetadata("hash-a");
+        final var fileB = getFileMetadata("hash-b");
+        final var fileC = getFileMetadata("hash-c");
+        final var scope = List.of(fileA1, fileB, fileC, fileA2, fileA3);
+
+        //when
+        final var actual = partitioner.partitionBackupScope(scope);
+
+        //then
+        Assertions.assertTrue(actual.contains(List.of(List.of(fileA1, fileA2, fileA3))),
+                "A partition should contain fileA1, fileA2, fileA3");
+        Assertions.assertTrue(actual.contains(List.of(List.of(fileB))),
+                "A partition should contain fileB");
+        Assertions.assertTrue(actual.contains(List.of(List.of(fileC))),
+                "A partition should contain fileC");
+    }
+
+    private FileMetadata getFileMetadata(final String hash) {
+        return FileMetadata.builder()
+                .id(UUID.randomUUID())
+                .absolutePath(Path.of("test"))
+                .originalHash(hash)
+                .originalSizeBytes(1L)
+                .group("test")
+                .owner("test")
+                .status(Change.NEW)
+                .fileType(FileType.REGULAR_FILE)
+                .posixPermissions("rw-rw-rw-")
+                .createdUtcEpochSeconds(0L)
+                .lastModifiedUtcEpochSeconds(0L)
+                .lastAccessedUtcEpochSeconds(0L)
+                .fileSystemKey("key")
+                .build();
+    }
+}

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/enums/DuplicateHandlingStrategyTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/enums/DuplicateHandlingStrategyTest.java
@@ -1,0 +1,119 @@
+package com.github.nagyesta.filebarj.core.config.enums;
+
+import com.github.nagyesta.filebarj.core.TempFileAwareTest;
+import com.github.nagyesta.filebarj.core.model.FileMetadata;
+import com.github.nagyesta.filebarj.core.model.enums.Change;
+import com.github.nagyesta.filebarj.core.model.enums.FileType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.github.nagyesta.filebarj.core.config.enums.DuplicateHandlingStrategy.KEEP_EACH;
+import static com.github.nagyesta.filebarj.core.config.enums.DuplicateHandlingStrategy.KEEP_ONE_PER_BACKUP;
+import static com.github.nagyesta.filebarj.core.config.enums.HashAlgorithm.NONE;
+import static com.github.nagyesta.filebarj.core.config.enums.HashAlgorithm.SHA256;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DuplicateHandlingStrategyTest extends TempFileAwareTest {
+
+    public static final long NOW = Instant.now().getEpochSecond();
+    public static final long A_MINUTE_AGO = NOW - 60;
+
+    public static Stream<Arguments> groupingProvider() {
+        final var original = getRegularFileMetadata("file.png", 20, "hash1", NOW);
+        final var duplicateDifferentName = getRegularFileMetadata("file2.png", 20, "hash1", NOW);
+        final var differentSize = getRegularFileMetadata("file2.png", 21, "hash1", NOW);
+        final var differentHash = getRegularFileMetadata("false/file.png", 20, "hash2", NOW);
+        final var duplicateSubFolder = getRegularFileMetadata("sub/file.png", 20, "hash1", NOW);
+        final var duplicateSubFolderDifferentHash = getRegularFileMetadata("diff/file.png", 20, "hash2", NOW);
+        final var duplicateSubFolderDifferentTime = getRegularFileMetadata("time/file.png", 20, "hash1", A_MINUTE_AGO);
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, original, SHA256, true))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, duplicateDifferentName, SHA256, true))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, differentSize, SHA256, false))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, differentHash, SHA256, false))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, duplicateSubFolder, SHA256, true))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, duplicateSubFolderDifferentHash, SHA256, false))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, duplicateSubFolderDifferentTime, SHA256, true))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, original, NONE, true))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, duplicateDifferentName, NONE, false))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, differentSize, NONE, false))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, differentHash, NONE, true))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, duplicateSubFolder, NONE, true))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, duplicateSubFolderDifferentHash, NONE, true))
+                .add(Arguments.of(KEEP_ONE_PER_BACKUP, original, duplicateSubFolderDifferentTime, NONE, false))
+                .add(Arguments.of(KEEP_EACH, original, original, SHA256, true))
+                .add(Arguments.of(KEEP_EACH, original, duplicateDifferentName, SHA256, false))
+                .add(Arguments.of(KEEP_EACH, original, differentSize, SHA256, false))
+                .add(Arguments.of(KEEP_EACH, original, differentHash, SHA256, false))
+                .add(Arguments.of(KEEP_EACH, original, duplicateSubFolder, SHA256, false))
+                .add(Arguments.of(KEEP_EACH, original, duplicateSubFolderDifferentHash, SHA256, false))
+                .add(Arguments.of(KEEP_EACH, original, duplicateSubFolderDifferentTime, SHA256, false))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("groupingProvider")
+    void testFileGroupingFunctionForHashShouldGenerateSameKeyWhenCalledWithDuplicatesOfTheSameFile(
+            final DuplicateHandlingStrategy underTest,
+            final FileMetadata fileMetadata1, final FileMetadata fileMetadata2,
+            final HashAlgorithm hashAlgorithm, final boolean expected) {
+        //given
+
+        //when
+        final var first = underTest.fileGroupingFunctionForHash(hashAlgorithm).apply(fileMetadata1);
+        final var second = underTest.fileGroupingFunctionForHash(hashAlgorithm).apply(fileMetadata2);
+
+        //then
+        assertEquals(expected, first.equals(second));
+    }
+
+    @SuppressWarnings({"UnnecessaryLocalVariable", "DataFlowIssue"})
+    @Test
+    void testFileGroupingFunctionForHashOfKeepEachShouldThrowExceptionWhenCalledWithNullHash() {
+        //given
+        final var underTest = DuplicateHandlingStrategy.KEEP_EACH;
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.fileGroupingFunctionForHash(null));
+
+        //then + exception
+    }
+
+    @SuppressWarnings({"UnnecessaryLocalVariable", "DataFlowIssue"})
+    @Test
+    void testFileGroupingFunctionForHashOfKeepOnePerBackupShouldThrowExceptionWhenCalledWithNullHash() {
+        //given
+        final var underTest = DuplicateHandlingStrategy.KEEP_ONE_PER_BACKUP;
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.fileGroupingFunctionForHash(null));
+
+        //then + exception
+    }
+
+    private static FileMetadata getRegularFileMetadata(
+            final String name, final long size, final String hash, final long lastModified) {
+        return FileMetadata.builder()
+                .absolutePath(Path.of(name))
+                .fileType(FileType.REGULAR_FILE)
+                .id(UUID.randomUUID())
+                .originalHash(hash)
+                .originalSizeBytes(size)
+                .lastModifiedUtcEpochSeconds(lastModified)
+                .createdUtcEpochSeconds(Instant.now().minusSeconds(1).getEpochSecond())
+                .lastAccessedUtcEpochSeconds(NOW)
+                .posixPermissions("rwxrwxrwx")
+                .owner("owner")
+                .group("group")
+                .status(Change.NEW)
+                .build();
+    }
+}

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/enums/HashAlgorithmTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/enums/HashAlgorithmTest.java
@@ -1,0 +1,107 @@
+package com.github.nagyesta.filebarj.core.config.enums;
+
+import com.github.nagyesta.filebarj.core.model.FileMetadata;
+import com.github.nagyesta.filebarj.core.model.enums.Change;
+import com.github.nagyesta.filebarj.core.model.enums.FileType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HashAlgorithmTest {
+
+    public static final long NOW = Instant.now().getEpochSecond();
+    public static final long A_MINUTE_AGO = NOW - 60;
+
+    public static Stream<Arguments> sizeBasedGroupingProvider() {
+        final var original = getRegularFileMetadata("file.png", 20, "hash1", NOW);
+        final var duplicateDifferentName = getRegularFileMetadata("file2.png", 20, "hash1", NOW);
+        final var differentSize = getRegularFileMetadata("file2.png", 21, "hash1", NOW);
+        final var differentHash = getRegularFileMetadata("false/file.png", 20, "hash2", NOW);
+        final var duplicateSubFolder = getRegularFileMetadata("sub/file.png", 20, "hash1", NOW);
+        final var duplicateSubFolderDifferentHash = getRegularFileMetadata("diff/file.png", 20, "hash2", NOW);
+        final var duplicateSubFolderDifferentTime = getRegularFileMetadata("time/file.png", 20, "hash1", A_MINUTE_AGO);
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(original, original, true))
+                .add(Arguments.of(original, duplicateDifferentName, false))
+                .add(Arguments.of(original, differentSize, false))
+                .add(Arguments.of(original, differentHash, true))
+                .add(Arguments.of(original, duplicateSubFolder, true))
+                .add(Arguments.of(original, duplicateSubFolderDifferentHash, true))
+                .add(Arguments.of(original, duplicateSubFolderDifferentTime, false))
+                .build();
+    }
+
+    public static Stream<Arguments> hashBasedGroupingProvider() {
+        final var original = getRegularFileMetadata("file.png", 20, "hash1", NOW);
+        final var duplicateDifferentName = getRegularFileMetadata("file2.png", 20, "hash1", NOW);
+        final var differentSize = getRegularFileMetadata("file2.png", 21, "hash1", NOW);
+        final var differentHash = getRegularFileMetadata("false/file.png", 20, "hash2", NOW);
+        final var duplicateSubFolder = getRegularFileMetadata("sub/file.png", 20, "hash1", NOW);
+        final var duplicateSubFolderDifferentHash = getRegularFileMetadata("diff/file.png", 20, "hash2", NOW);
+        final var duplicateSubFolderDifferentTime = getRegularFileMetadata("time/file.png", 20, "hash1", A_MINUTE_AGO);
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(original, original, true))
+                .add(Arguments.of(original, duplicateDifferentName, true))
+                .add(Arguments.of(original, differentSize, false))
+                .add(Arguments.of(original, differentHash, false))
+                .add(Arguments.of(original, duplicateSubFolder, true))
+                .add(Arguments.of(original, duplicateSubFolderDifferentHash, false))
+                .add(Arguments.of(original, duplicateSubFolderDifferentTime, true))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("sizeBasedGroupingProvider")
+    void testFileGroupingFunctionShouldGenerateSameKeyWhenCalledOnNoneHashWithDuplicatesOfTheSameFile(
+            final FileMetadata fileMetadata1, final FileMetadata fileMetadata2, final boolean expected) {
+        //given
+        final var underTest = HashAlgorithm.NONE;
+
+        //when
+        final var first = underTest.fileGroupingFunction().apply(fileMetadata1);
+        final var second = underTest.fileGroupingFunction().apply(fileMetadata2);
+
+        //then
+        assertEquals(expected, first.equals(second));
+    }
+
+    @ParameterizedTest
+    @MethodSource("hashBasedGroupingProvider")
+    void testFileGroupingFunctionShouldGenerateSameKeyWhenCalledOnShaHashWithDuplicatesOfTheSameFile(
+            final FileMetadata fileMetadata1, final FileMetadata fileMetadata2, final boolean expected) {
+        //given
+        final var underTest = HashAlgorithm.SHA256;
+
+        //when
+        final var first = underTest.fileGroupingFunction().apply(fileMetadata1);
+        final var second = underTest.fileGroupingFunction().apply(fileMetadata2);
+
+        //then
+        assertEquals(expected, first.equals(second));
+    }
+
+    private static FileMetadata getRegularFileMetadata(
+            final String name, final long size, final String hash, final long lastModified) {
+        return FileMetadata.builder()
+                .absolutePath(Path.of(name))
+                .fileType(FileType.REGULAR_FILE)
+                .id(UUID.randomUUID())
+                .originalHash(hash)
+                .originalSizeBytes(size)
+                .lastModifiedUtcEpochSeconds(lastModified)
+                .createdUtcEpochSeconds(Instant.now().minusSeconds(1).getEpochSecond())
+                .lastAccessedUtcEpochSeconds(NOW)
+                .posixPermissions("rwxrwxrwx")
+                .owner("owner")
+                .group("group")
+                .status(Change.NEW)
+                .build();
+    }
+}

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestorePipelineIntegrationTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestorePipelineIntegrationTest.java
@@ -202,6 +202,25 @@ class RestorePipelineIntegrationTest extends TempFileAwareTest {
         //then + exception
     }
 
+    @Test
+    void testEvaluateRestoreSuccessShouldNotThrowExceptionWhenCalledWithoutRestoringBackup() throws IOException {
+        //given
+        final var backupController = executeABackup();
+        final var backupDirectory = testDataRoot.resolve("backup-dir");
+        final var restoreDirectory = testDataRoot.resolve("restore-dir");
+        final var manifest = backupController.getManifest();
+        final var restoreManifest = new ManifestManagerImpl().mergeForRestore(new TreeMap<>(Map.of(0, manifest)));
+        final var sourceDirectory = getSourceDirectory(backupController);
+        final var restoreTargets = getRestoreTargets(sourceDirectory, restoreDirectory);
+
+        final var underTest = new RestorePipeline(restoreManifest, backupDirectory, restoreTargets, null);
+
+        //when
+        underTest.evaluateRestoreSuccess(manifest.getFiles().values().stream().toList());
+
+        //then no exception
+    }
+
     @SuppressWarnings("DataFlowIssue")
     @Test
     void testRestoreDirectoriesShouldThrowExceptionWhenCalledWithNull() throws IOException {


### PR DESCRIPTION
__Issue:__ #96

### Description
<!-- A short summary of changes -->

- Removes KEEP_ONE_PER_INCREMENT constant as this duplication strategy does not make sense
- Implements duplication strategies comparing files as the configured hash algorithm dictates
- Adds error to the backup if the hash changed between parse and backup
- Restore pipeline logs warning when restoring an archived file with any errors saved to the backup
- Adds new test cases
- Updates documentation

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [ ] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
