### PR TITLE
Allow deleting left-over files after restore completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ File BaRJ comes with the following features
 - Backup archive integrity checks
 - Restore/unpack previous backup
 - Duplicate handling (storing duplicates of the same file only once)
+- Deletes left-over files from the restore directory (if they had been in scope for the backup)
 
 ### Planned features
 
@@ -54,3 +55,4 @@ File BaRJ comes with the following features
 # Limitations
 
 - The file permissions are only captured from the point of view of the current user on Windows or other non-POSIX compliant systems.
+- Restoring a backup on a different OS is not working well (See #94).

--- a/file-barj-core/README.md
+++ b/file-barj-core/README.md
@@ -40,10 +40,10 @@ at its core.
 implementation("com.github.nagyesta.file-barj:file-barj-core:+")
 ```
 
-### Creating a backup configuration
+### Writing an archive
 
 ```java
-
+//configuring the backup job
 final var configuration = BackupJobConfiguration.builder()
         .backupType(BackupType.FULL)
         .fileNamePrefix("test")
@@ -57,22 +57,28 @@ final var configuration = BackupJobConfiguration.builder()
         .chunkSizeMebibyte(1)
         .encryptionKey(null)
         .build();
-```
-
-### Writing an archive
-
-```java
 final var backupController = new BackupController(configuration, false);
+
+//executing the backup
 backupController.execute(1);
 ```
 
 ### Reading an archive
 
 ```java
-final var restoreController = new RestoreController(Path.of("/tmp/backup"), "test", null);
+//configuring the restore job
 final var restoreTargets = new RestoreTargets(
         Set.of(new RestoreTarget(Path.of("/source/dir"), Path.of("/tmp/restore/to"))));
-restoreController.execute(restoreTargets, 1, false);
+final var restoreTask = RestoreTask.builder()
+        .restoreTargets(restoreTargets)
+        .dryRun(true)
+        .threads(1)
+        .deleteFilesNotInBackup(false)
+        .build();
+final var restoreController = new RestoreController(Path.of("/tmp/backup"), "test", null);
+
+//executing the restore
+restoreController.execute(restoreTask);
 ```
 
 ## Further reading

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/worker/PosixFileMetadataParser.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/backup/worker/PosixFileMetadataParser.java
@@ -37,7 +37,7 @@ public class PosixFileMetadataParser implements FileMetadataParser {
     @Override
     public FileMetadata parse(
             @NonNull final File file, @NonNull final BackupJobConfiguration configuration) {
-        if (!file.exists()) {
+        if (!Files.exists(file.toPath(), LinkOption.NOFOLLOW_LINKS)) {
             return FileMetadata.builder()
                     .id(UUID.randomUUID())
                     .absolutePath(file.toPath().toAbsolutePath())

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/RestoreTargets.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/RestoreTargets.java
@@ -11,7 +11,7 @@ import java.util.Set;
  *
  * @param restoreTargets the restore targets
  */
-public record RestoreTargets(Set<RestoreTarget> restoreTargets) {
+public record RestoreTargets(@NonNull Set<RestoreTarget> restoreTargets) {
 
     /**
      * Converts the original path to the restore path.

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/RestoreTask.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/RestoreTask.java
@@ -1,0 +1,32 @@
+package com.github.nagyesta.filebarj.core.config;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+
+/**
+ * Defines the parameters of a restore task.
+ */
+@Data
+@Builder
+public class RestoreTask {
+
+    /**
+     * Defines the target directories to restore files to.
+     */
+    @NonNull
+    private final RestoreTargets restoreTargets;
+    /**
+     * The number of threads to use for parallel restore.
+     */
+    private final int threads;
+    /**
+     * Disallows file system changes when true.
+     */
+    private final boolean dryRun;
+    /**
+     * Allows deleting files from the restore targets which would have been in the backup scope but
+     * are not in the backup increment when true.
+     */
+    private final boolean deleteFilesNotInBackup;
+}

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestoreController.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestoreController.java
@@ -3,6 +3,7 @@ package com.github.nagyesta.filebarj.core.restore.pipeline;
 import com.github.nagyesta.filebarj.core.common.ManifestManager;
 import com.github.nagyesta.filebarj.core.common.ManifestManagerImpl;
 import com.github.nagyesta.filebarj.core.config.RestoreTargets;
+import com.github.nagyesta.filebarj.core.config.RestoreTask;
 import com.github.nagyesta.filebarj.core.model.FileMetadata;
 import com.github.nagyesta.filebarj.core.model.RestoreManifest;
 import com.github.nagyesta.filebarj.core.model.enums.FileType;
@@ -60,34 +61,31 @@ public class RestoreController {
     /**
      * Execute the restore to the provided root directory.
      *
-     * @param restoreTargets the directory mappings where we want to restore our files
-     * @param threads        The number of threads to use
-     * @param dryRun         Whether to perform a dry-run (preventing file system changes)
+     * @param restoreTask the parameters of the task we need to perform when we execute the restore
      */
     public void execute(
-            @NonNull final RestoreTargets restoreTargets,
-            final int threads,
-            final boolean dryRun) {
-        if (threads < 1) {
-            throw new IllegalArgumentException("Invalid number of threads: " + threads);
+            @NonNull final RestoreTask restoreTask) {
+        if (restoreTask.getThreads() < 1) {
+            throw new IllegalArgumentException("Invalid number of threads: " + restoreTask.getThreads());
         }
         executionLock.lock();
         try {
-            this.threadPool = new ForkJoinPool(threads);
+            this.threadPool = new ForkJoinPool(restoreTask.getThreads());
             final var allEntries = manifest.getFilesOfLastManifest().values().stream().toList();
             final var contentSources = manifest.getExistingContentSourceFilesOfLastManifest();
             final long totalBackupSize = allEntries.stream()
                     .map(FileMetadata::getOriginalSizeBytes)
                     .reduce(0L, Long::sum);
-            restoreTargets.restoreTargets()
+            restoreTask.getRestoreTargets().restoreTargets()
                     .forEach(target -> log.info("Restoring {} to {}", target.backupPath(), target.restorePath()));
             log.info("Starting restore of {} MiB backup content (delta not known yet)", totalBackupSize / MEBIBYTE);
             final var startTimeMillis = System.currentTimeMillis();
-            final var pipeline = createRestorePipeline(restoreTargets, dryRun);
+            final var pipeline = createRestorePipeline(restoreTask.getRestoreTargets(), restoreTask.isDryRun());
             pipeline.restoreDirectories(allEntries.stream()
                     .filter(metadata -> metadata.getFileType() == FileType.DIRECTORY)
                     .toList());
             pipeline.restoreFiles(contentSources, threadPool);
+            pipeline.deleteLeftOverFiles(restoreTask.isDeleteFilesNotInBackup(), threadPool);
             pipeline.finalizePermissions(allEntries, threadPool);
             pipeline.evaluateRestoreSuccess(allEntries, threadPool);
             final var endTimeMillis = System.currentTimeMillis();

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/RestoreTargetsTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/RestoreTargetsTest.java
@@ -58,4 +58,15 @@ class RestoreTargetsTest extends TempFileAwareTest {
 
         //then + exception
     }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalledWithNull() {
+        //given
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new RestoreTargets(null));
+
+        //then + exception
+    }
 }

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/RestoreTaskTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/RestoreTaskTest.java
@@ -1,0 +1,46 @@
+package com.github.nagyesta.filebarj.core.config;
+
+import com.github.nagyesta.filebarj.core.TempFileAwareTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+class RestoreTaskTest extends TempFileAwareTest {
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testBuilderShouldThrowExceptionWhenCalledWithNullRestoreTargets() {
+        //given
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> RestoreTask.builder()
+                .restoreTargets(null));
+
+        //then + exception
+    }
+
+    @Test
+    void testBuilderShouldCreateInstanceWhenCalledWithValidData() {
+        //given
+        final var dryRun = true;
+        final var threads = 2;
+        final var deleteFilesNotInBackup = true;
+        final var restoreTargets = new RestoreTargets(Set.of(new RestoreTarget(Path.of("source"), Path.of("target"))));
+
+        //when
+        final var actual = RestoreTask.builder()
+                .restoreTargets(restoreTargets)
+                .dryRun(dryRun)
+                .threads(threads)
+                .deleteFilesNotInBackup(deleteFilesNotInBackup)
+                .build();
+
+        //then
+        Assertions.assertEquals(dryRun, actual.isDryRun());
+        Assertions.assertEquals(threads, actual.getThreads());
+        Assertions.assertEquals(deleteFilesNotInBackup, actual.isDeleteFilesNotInBackup());
+        Assertions.assertEquals(restoreTargets, actual.getRestoreTargets());
+    }
+}

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestorePipelineIntegrationTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestorePipelineIntegrationTest.java
@@ -373,6 +373,27 @@ class RestorePipelineIntegrationTest extends TempFileAwareTest {
         Assertions.assertEquals(externalLinkTarget, restoredExternal);
     }
 
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testDeleteLeftOverFilesShouldThrowExceptionWhenCalledWithNullThreadPool() throws IOException {
+        //given
+        final var backupController = executeABackup();
+        final var backupDirectory = testDataRoot.resolve("backup-dir");
+        final var restoreDirectory = testDataRoot.resolve("restore-dir");
+        final var manifest = backupController.getManifest();
+        final var restoreManifest = new ManifestManagerImpl().mergeForRestore(new TreeMap<>(Map.of(0, manifest)));
+        final var sourceDirectory = getSourceDirectory(backupController);
+        final var restoreTargets = getRestoreTargets(sourceDirectory, restoreDirectory);
+
+        final var underTest = new RestorePipeline(restoreManifest, backupDirectory, restoreTargets, null);
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> underTest.deleteLeftOverFiles(true, null));
+
+        //then + exception
+    }
+
     private Path getSourceDirectory(final BackupController backupController) {
         return backupController.getManifest().getConfiguration().getSources().stream()
                 .findAny()

--- a/file-barj-job/README.md
+++ b/file-barj-job/README.md
@@ -59,6 +59,7 @@ java -jar build/libs/file-barj-job.jar \
      --prefix backup-job-file-prefix \
      --target-mapping /original/path=/restore/path \
      --dry-run true \
+     --delete-missing true \
      --key-store keys.p12 \
      --key-alias alias \
      --threads 2

--- a/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/Controller.java
+++ b/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/Controller.java
@@ -5,6 +5,7 @@ import com.github.nagyesta.filebarj.core.backup.pipeline.BackupController;
 import com.github.nagyesta.filebarj.core.config.BackupJobConfiguration;
 import com.github.nagyesta.filebarj.core.config.RestoreTarget;
 import com.github.nagyesta.filebarj.core.config.RestoreTargets;
+import com.github.nagyesta.filebarj.core.config.RestoreTask;
 import com.github.nagyesta.filebarj.core.restore.pipeline.RestoreController;
 import com.github.nagyesta.filebarj.io.stream.crypto.EncryptionUtil;
 import com.github.nagyesta.filebarj.job.cli.*;
@@ -90,8 +91,14 @@ public class Controller {
         );
         final var startTimeMillis = System.currentTimeMillis();
         log.info("Bootstrapping restore operation...");
+        final var restoreTask = RestoreTask.builder()
+                .restoreTargets(restoreTargets)
+                .threads(properties.getThreads())
+                .dryRun(properties.isDryRun())
+                .deleteFilesNotInBackup(properties.isDeleteFilesNotInBackup())
+                .build();
         new RestoreController(properties.getBackupSource(), properties.getPrefix(), kek)
-                .execute(restoreTargets, properties.getThreads(), properties.isDryRun());
+                .execute(restoreTask);
         final var endTimeMillis = System.currentTimeMillis();
         final var durationMillis = (endTimeMillis - startTimeMillis);
         log.info("Restore operation completed. Total time: {}", toProcessSummary(durationMillis));

--- a/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/CliRestoreParser.java
+++ b/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/CliRestoreParser.java
@@ -22,6 +22,7 @@ public class CliRestoreParser extends GenericCliParser<RestoreProperties> {
     private static final String KEY_ALIAS = "key-alias";
     private static final String PREFIX = "prefix";
     private static final String TARGET = "target-mapping";
+    private static final String DELETE_MISSING = "delete-missing";
 
     private static Options createOptions() {
         return new Options()
@@ -38,6 +39,13 @@ public class CliRestoreParser extends GenericCliParser<RestoreProperties> {
                         .argName("boolean")
                         .type(Boolean.class)
                         .desc("Only simulates file operations if provided.").build())
+                .addOption(Option.builder()
+                        .longOpt(DELETE_MISSING)
+                        .numberOfArgs(1)
+                        .argName("boolean")
+                        .type(Boolean.class)
+                        .desc("Allow deleting the files from the target directory that are matching the backup source patterns "
+                                + "but are not present in the backup increment.").build())
                 .addOption(Option.builder()
                         .longOpt(BACKUP_SOURCE)
                         .required()
@@ -89,6 +97,7 @@ public class CliRestoreParser extends GenericCliParser<RestoreProperties> {
         super("java -jar file-barj-job.jar --" + Task.RESTORE.getCommand(), createOptions(), args, commandLine -> {
             final var threads = Integer.parseInt(commandLine.getOptionValue(THREADS, "1"));
             final var dryRun = Boolean.parseBoolean(commandLine.getOptionValue(DRY_RUN, "false"));
+            final var deleteMissing = Boolean.parseBoolean(commandLine.getOptionValue(DELETE_MISSING, "false"));
             final var backupSource = Path.of(commandLine.getOptionValue(BACKUP_SOURCE)).toAbsolutePath();
             final var prefix = commandLine.getOptionValue(PREFIX);
             final var targets = new HashMap<Path, Path>();
@@ -118,6 +127,7 @@ public class CliRestoreParser extends GenericCliParser<RestoreProperties> {
             return RestoreProperties.builder()
                     .threads(threads)
                     .dryRun(dryRun)
+                    .deleteFilesNotInBackup(deleteMissing)
                     .backupSource(backupSource)
                     .keyProperties(keyProperties)
                     .prefix(prefix)

--- a/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/RestoreProperties.java
+++ b/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/RestoreProperties.java
@@ -22,4 +22,5 @@ public class RestoreProperties {
     private final Map<Path, Path> targets;
     private final int threads;
     private final boolean dryRun;
+    private final boolean deleteFilesNotInBackup;
 }


### PR DESCRIPTION
__Issue:__ #106

### Description
<!-- A short summary of changes -->

- Adds new command line flag --delete-missing
- Collects and deletes left-over files during RestoreController execution
- Adds/updates tests
- Updates documentation

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
