### PR TITLE
Restoring a Unix Backup on Windows is not working well

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ File BaRJ comes with the following features
 # Limitations
 
 - The file permissions are only captured from the point of view of the current user on Windows or other non-POSIX compliant systems.
-- Restoring a backup on a different OS is not working well (See #94).
+- Cross platform restore can run into file name case issues when restoring a backup using case-sensitive paths on a system where paths are case-insensitive. 

--- a/file-barj-core/README.md
+++ b/file-barj-core/README.md
@@ -75,6 +75,7 @@ final var restoreTask = RestoreTask.builder()
         .threads(1)
         .deleteFilesNotInBackup(false)
         .includedPath(BackupPath.of("/source/dir")) //optional path filter
+        .permissionComparisonStrategy(PermissionComparisonStrategy.STRICT) //optional
         .build();
 final var pointInTime = 123456L;
 final var restoreController = new RestoreController(Path.of("/tmp/backup"), "test", null, pointInTime);

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/BaseFileMetadataChangeDetector.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/BaseFileMetadataChangeDetector.java
@@ -4,7 +4,9 @@ import com.github.nagyesta.filebarj.core.model.BackupPath;
 import com.github.nagyesta.filebarj.core.model.FileMetadata;
 import com.github.nagyesta.filebarj.core.model.enums.Change;
 import com.github.nagyesta.filebarj.core.model.enums.FileType;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,6 +22,10 @@ public abstract class BaseFileMetadataChangeDetector<T> implements FileMetadataC
     private final SortedMap<String, Map<UUID, FileMetadata>> filesFromManifests;
     private final SortedMap<String, Map<T, List<FileMetadata>>> contentIndex;
     private final Map<String, FileMetadata> nameIndex;
+    @NonNull
+    @Getter
+    @Setter
+    private PermissionComparisonStrategy permissionComparisonStrategy = PermissionComparisonStrategy.STRICT;
 
     /**
      * Creates a new instance with the previous manifests.
@@ -40,9 +46,7 @@ public abstract class BaseFileMetadataChangeDetector<T> implements FileMetadataC
     public boolean hasMetadataChanged(
             @NonNull final FileMetadata previousMetadata,
             @NonNull final FileMetadata currentMetadata) {
-        final var permissionsChanged = !Objects.equals(currentMetadata.getOwner(), previousMetadata.getOwner())
-                || !Objects.equals(currentMetadata.getGroup(), previousMetadata.getGroup())
-                || !Objects.equals(currentMetadata.getPosixPermissions(), previousMetadata.getPosixPermissions());
+        final var permissionsChanged = !permissionComparisonStrategy.matches(previousMetadata, currentMetadata);
         final var hiddenStatusChanged = currentMetadata.getHidden() != previousMetadata.getHidden();
         final var timesChanged = currentMetadata.getFileType() != FileType.SYMBOLIC_LINK
                 && (!Objects.equals(currentMetadata.getCreatedUtcEpochSeconds(), previousMetadata.getCreatedUtcEpochSeconds())

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/ManifestManagerImpl.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/ManifestManagerImpl.java
@@ -6,7 +6,7 @@ import com.github.nagyesta.filebarj.core.config.BackupJobConfiguration;
 import com.github.nagyesta.filebarj.core.model.*;
 import com.github.nagyesta.filebarj.core.model.enums.BackupType;
 import com.github.nagyesta.filebarj.core.model.enums.Change;
-import com.github.nagyesta.filebarj.core.util.StatLogUtil;
+import com.github.nagyesta.filebarj.core.util.LogUtil;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -162,7 +162,7 @@ public class ManifestManagerImpl implements ManifestManager {
         final var filesToBeRestored = calculateRemainingFilesAndLinks(lastIncrementManifest);
         populateFilesAndArchiveEntries(manifests, filesToBeRestored, files, archivedEntries);
         files.forEach((key, value) -> {
-            StatLogUtil.logStatistics(value.values(),
+            LogUtil.logStatistics(value.values(),
                     (type, count) -> log.info("Increment {} contains {} {} items.", key, count, type));
         });
         return RestoreManifest.builder()

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/PermissionComparisonStrategy.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/PermissionComparisonStrategy.java
@@ -1,0 +1,84 @@
+package com.github.nagyesta.filebarj.core.common;
+
+import com.github.nagyesta.filebarj.core.model.FileMetadata;
+import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Implements multiple strategies for comparing permissions.
+ */
+public enum PermissionComparisonStrategy {
+
+    /**
+     * Compare permissions, owner and group names strictly.
+     */
+    STRICT {
+        @Override
+        public boolean matches(
+                @NonNull final FileMetadata previousMetadata,
+                @NonNull final FileMetadata currentMetadata) {
+            return Objects.equals(previousMetadata.getPosixPermissions(), currentMetadata.getPosixPermissions())
+                    && Objects.equals(previousMetadata.getOwner(), currentMetadata.getOwner())
+                    && Objects.equals(previousMetadata.getGroup(), currentMetadata.getGroup());
+        }
+    },
+
+    /**
+     * Compare permissions only ignoring owner and group names.
+     */
+    PERMISSION_ONLY {
+        @Override
+        public boolean matches(
+                @NonNull final FileMetadata previousMetadata,
+                @NonNull final FileMetadata currentMetadata) {
+            return Objects.equals(previousMetadata.getPosixPermissions(), currentMetadata.getPosixPermissions());
+        }
+    },
+
+    /**
+     * Only compare the first three characters of permissions, ignoring owner and group names.
+     */
+    RELAXED {
+        private static final int FIRST_SIGNIFICANT_CHAR_INCLUSIVE = 0;
+        private static final int LAST_SIGNIFICANT_CHAR_EXCLUSIVE = 3;
+        @Override
+        public boolean matches(
+                @NonNull final FileMetadata previousMetadata,
+                @NonNull final FileMetadata currentMetadata) {
+            return Objects.equals(transform(previousMetadata.getPosixPermissions()), transform(currentMetadata.getPosixPermissions()));
+        }
+
+        @Nullable
+        private static String transform(final String permissions) {
+            return Optional.ofNullable(permissions)
+                    .map(s -> s.substring(FIRST_SIGNIFICANT_CHAR_INCLUSIVE, LAST_SIGNIFICANT_CHAR_EXCLUSIVE))
+                    .orElse(null);
+        }
+    },
+
+    /**
+     * Ignore permission and owner/group name differences.
+     */
+    IGNORE {
+        @Override
+        public boolean matches(
+                @NonNull final FileMetadata previousMetadata,
+                @NonNull final FileMetadata currentMetadata) {
+            return true;
+        }
+    };
+
+    /**
+     * Compares the permissions, owner name and group name.
+     *
+     * @param previousMetadata The previous metadata
+     * @param currentMetadata  The current metadata
+     * @return true if the permissions are the same
+     */
+    public abstract boolean matches(
+            @NonNull FileMetadata previousMetadata,
+            @NonNull FileMetadata currentMetadata);
+}

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/RestoreTask.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/RestoreTask.java
@@ -1,5 +1,6 @@
 package com.github.nagyesta.filebarj.core.config;
 
+import com.github.nagyesta.filebarj.core.common.PermissionComparisonStrategy;
 import com.github.nagyesta.filebarj.core.model.BackupPath;
 import lombok.Builder;
 import lombok.Data;
@@ -37,6 +38,13 @@ public class RestoreTask {
      * The root path of the backup entries (directory or file) to include during the restore.
      */
     private final BackupPath includedPath;
+    /**
+     * The strategy to use when comparing permissions.
+     * <br/>
+     * Defaults to {@link PermissionComparisonStrategy#STRICT}.
+     */
+    @Builder.Default
+    private final PermissionComparisonStrategy permissionComparisonStrategy = PermissionComparisonStrategy.STRICT;
 
     /**
      * Returns the path filter for this restore task based on the included path.

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestoreController.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestoreController.java
@@ -8,7 +8,7 @@ import com.github.nagyesta.filebarj.core.inspect.worker.ManifestToSummaryConvert
 import com.github.nagyesta.filebarj.core.model.FileMetadata;
 import com.github.nagyesta.filebarj.core.model.RestoreManifest;
 import com.github.nagyesta.filebarj.core.model.enums.FileType;
-import com.github.nagyesta.filebarj.core.util.StatLogUtil;
+import com.github.nagyesta.filebarj.core.util.LogUtil;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -72,7 +72,7 @@ public class RestoreController {
         log.info("Merging {} manifests", manifests.size());
         manifest = manifestManager.mergeForRestore(manifests);
         final var filesOfLastManifest = manifest.getFilesOfLastManifest();
-        StatLogUtil.logStatistics(filesOfLastManifest.values(),
+        LogUtil.logStatistics(filesOfLastManifest.values(),
                 (type, count) -> log.info("Found {} {} items in merged backup", count, type));
     }
 

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestorePipeline.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/restore/pipeline/RestorePipeline.java
@@ -11,7 +11,7 @@ import com.github.nagyesta.filebarj.core.model.enums.Change;
 import com.github.nagyesta.filebarj.core.model.enums.FileType;
 import com.github.nagyesta.filebarj.core.restore.worker.FileMetadataSetter;
 import com.github.nagyesta.filebarj.core.restore.worker.FileMetadataSetterFactory;
-import com.github.nagyesta.filebarj.core.util.StatLogUtil;
+import com.github.nagyesta.filebarj.core.util.LogUtil;
 import com.github.nagyesta.filebarj.io.stream.BarjCargoArchiveFileInputStreamSource;
 import com.github.nagyesta.filebarj.io.stream.BarjCargoInputStreamConfiguration;
 import com.github.nagyesta.filebarj.io.stream.exception.ArchiveIntegrityException;
@@ -153,11 +153,11 @@ public class RestorePipeline {
                 .sorted(Comparator.comparing(FileMetadata::getAbsolutePath).reversed())
                 .forEachOrdered(fileMetadata -> {
                     setFileProperties(fileMetadata);
-                    StatLogUtil.logIfThresholdReached(doneCount.incrementAndGet(), filesWithMetadataChanges.size(),
+                    LogUtil.logIfThresholdReached(doneCount.incrementAndGet(), filesWithMetadataChanges.size(),
                             (done, total) -> log.info("Finalized metadata for {} of {} paths.", done, total));
                 });
-        final var totalCount = StatLogUtil.countsByType(files);
-        final var changedCount = StatLogUtil.countsByType(filesWithMetadataChanges);
+        final var totalCount = LogUtil.countsByType(files);
+        final var changedCount = LogUtil.countsByType(filesWithMetadataChanges);
         changedCount.keySet().forEach(type -> log.info("Finalized metadata for {} of {} {} entries.",
                 changedCount.get(type), totalCount.get(type), type));
     }
@@ -521,7 +521,7 @@ public class RestorePipeline {
                     final var restorePath = restoreTargets.mapToRestorePath(file.getAbsolutePath());
                     final var current = parser.parse(restorePath.toFile(), manifest.getConfiguration());
                     final var change = changeDetector.classifyChange(previous, current);
-                    StatLogUtil.logIfThresholdReached(doneCount.incrementAndGet(), files.size(),
+                    LogUtil.logIfThresholdReached(doneCount.incrementAndGet(), files.size(),
                             (done, total) -> log.info("Parsed {} of {} unique paths.", done, total));
                     changeStatuses.put(file.getAbsolutePath(), change);
                 })).join();

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/util/LogUtil.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/util/LogUtil.java
@@ -11,12 +11,23 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 /**
- * Utility class for file type statistics logging operations.
+ * Utility class for logging operations.
  */
 @UtilityClass
-public class StatLogUtil {
-
+public class LogUtil {
+    private static final String RESET = "\033[0;0m";
+    private static final String RED = "\033[0;31m";
     private static final int FOUR = 4;
+
+    /**
+     * Makes the message more prominent by applying a red colour.
+     *
+     * @param message the message
+     * @return the message with red colour
+     */
+    public static String scary(final String message) {
+        return RED + message + RESET;
+    }
 
     /**
      * Groups the files by their file type and calls the consumer for each group.

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/common/PermissionComparisonStrategyTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/common/PermissionComparisonStrategyTest.java
@@ -1,0 +1,176 @@
+package com.github.nagyesta.filebarj.core.common;
+
+import com.github.nagyesta.filebarj.core.TempFileAwareTest;
+import com.github.nagyesta.filebarj.core.model.FileMetadata;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PermissionComparisonStrategyTest extends TempFileAwareTest {
+
+    public Stream<Arguments> strictStrategyDataProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r-----"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        false))
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "r--r--r--"),
+                        false))
+                .add(Arguments.of(createFileMetadata("-", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        false))
+                .add(Arguments.of(createFileMetadata("owner", "-", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        false))
+                .add(Arguments.of(createFileMetadata("owner", "-", "rw-r--r--"),
+                        createFileMetadata(null, null, null),
+                        false))
+                .add(Arguments.of(createFileMetadata(null, null, null),
+                        createFileMetadata("owner", "-", "rw-r--r--"),
+                        false))
+                .build();
+    }
+
+    public Stream<Arguments> permissionOnlyStrategyDataProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r-----"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        false))
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "r--r--r--"),
+                        false))
+                .add(Arguments.of(createFileMetadata("-", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "-", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "-", "rw-r--r--"),
+                        createFileMetadata(null, null, null),
+                        false))
+                .add(Arguments.of(createFileMetadata(null, null, null),
+                        createFileMetadata("owner", "-", "rw-r--r--"),
+                        false))
+                .build();
+    }
+
+    public Stream<Arguments> relaxedStrategyDataProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r-----"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "r--r--r--"),
+                        false))
+                .add(Arguments.of(createFileMetadata("-", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "-", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "-", "rw-r--r--"),
+                        createFileMetadata(null, null, null),
+                        false))
+                .add(Arguments.of(createFileMetadata(null, null, null),
+                        createFileMetadata("owner", "-", "rw-r--r--"),
+                        false))
+                .build();
+    }
+
+    public Stream<Arguments> ignoreStrategyDataProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r-----"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "r--r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("-", "group", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "-", "rw-r--r--"),
+                        createFileMetadata("owner", "group", "rw-r--r--"),
+                        true))
+                .add(Arguments.of(createFileMetadata("owner", "-", "rw-r--r--"),
+                        createFileMetadata(null, null, null),
+                        true))
+                .add(Arguments.of(createFileMetadata(null, null, null),
+                        createFileMetadata("owner", "-", "rw-r--r--"),
+                        true))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("strictStrategyDataProvider")
+    void testStrictStrategyShouldNotAllowAnyDifferencesWhenCalled(
+            final FileMetadata previousMetadata, final FileMetadata currentMetadata, final boolean expectedResult) {
+        //given
+
+        //when
+        final var result = PermissionComparisonStrategy.STRICT.matches(previousMetadata, currentMetadata);
+        //then
+        assertEquals(expectedResult, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("permissionOnlyStrategyDataProvider")
+    void testPermissionOnlyStrategyShouldAllowDifferencesInOwnerAndGroupNameWhenCalled(
+            final FileMetadata previousMetadata, final FileMetadata currentMetadata, final boolean expectedResult) {
+        //given
+
+        //when
+        final var result = PermissionComparisonStrategy.PERMISSION_ONLY.matches(previousMetadata, currentMetadata);
+        //then
+        assertEquals(expectedResult, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("relaxedStrategyDataProvider")
+    void testRelaxedStrategyShouldAllowDifferencesInOwnerAndGroupNameWhenCalled(
+            final FileMetadata previousMetadata, final FileMetadata currentMetadata, final boolean expectedResult) {
+        //given
+
+        //when
+        final var result = PermissionComparisonStrategy.RELAXED.matches(previousMetadata, currentMetadata);
+        //then
+        assertEquals(expectedResult, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("ignoreStrategyDataProvider")
+    void testIgnoreStrategyShouldAllowDifferencesInOwnerAndGroupNameWhenCalled(
+            final FileMetadata previousMetadata, final FileMetadata currentMetadata, final boolean expectedResult) {
+        //given
+
+        //when
+        final var result = PermissionComparisonStrategy.IGNORE.matches(previousMetadata, currentMetadata);
+        //then
+        assertEquals(expectedResult, result);
+    }
+
+    private FileMetadata createFileMetadata(final String owner, final String group, final String permissions) {
+        final var mock = mock(FileMetadata.class);
+        when(mock.getOwner()).thenReturn(owner);
+        when(mock.getGroup()).thenReturn(group);
+        when(mock.getPosixPermissions()).thenReturn(permissions);
+        return mock;
+    }
+}

--- a/file-barj-job/README.md
+++ b/file-barj-job/README.md
@@ -64,6 +64,7 @@ java -jar build/libs/file-barj-job.jar \
      --key-alias alias \
      --at-epoch-seconds 123456 \
      --include-path /original/path/filter \
+     --permission-comparison STRICT \
      --threads 2
 ```
 

--- a/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/CliRestoreParser.java
+++ b/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/CliRestoreParser.java
@@ -1,5 +1,6 @@
 package com.github.nagyesta.filebarj.job.cli;
 
+import com.github.nagyesta.filebarj.core.common.PermissionComparisonStrategy;
 import com.github.nagyesta.filebarj.core.model.BackupPath;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.Option;
@@ -24,6 +25,7 @@ public class CliRestoreParser extends CliICommonBackupFileParser<RestoreProperti
     private static final String DELETE_MISSING = "delete-missing";
     private static final String AT_EPOCH_SECONDS = "at-epoch-seconds";
     private static final String INCLUDED_PATH = "include-path";
+    private static final String PERMISSION_COMPARISON = "permission-comparison";
 
     /**
      * Creates a new {@link CliRestoreParser} instance and sets the input arguments.
@@ -43,6 +45,8 @@ public class CliRestoreParser extends CliICommonBackupFileParser<RestoreProperti
             final var includedPath = Optional.ofNullable(commandLine.getOptionValue(INCLUDED_PATH))
                     .map(BackupPath::ofPathAsIs)
                     .orElse(null);
+            final var permissionComparison = PermissionComparisonStrategy
+                    .valueOf(commandLine.getOptionValue(PERMISSION_COMPARISON, PermissionComparisonStrategy.STRICT.name()));
             final var targets = new HashMap<BackupPath, Path>();
             if (commandLine.hasOption(TARGET)) {
                 final var mappings = commandLine.getOptionValues(TARGET);
@@ -67,6 +71,7 @@ public class CliRestoreParser extends CliICommonBackupFileParser<RestoreProperti
                     .targets(targets)
                     .pointInTimeEpochSeconds(atPointInTime)
                     .includedPath(includedPath)
+                    .permissionComparisonStrategy(permissionComparison)
                     .build();
         });
     }
@@ -118,6 +123,15 @@ public class CliRestoreParser extends CliICommonBackupFileParser<RestoreProperti
                         .type(Path.class)
                         .desc("Path of the file or directory which should be restored from the backup. Optional. If not provided,"
                                 + " all files should be restored.")
+                        .build())
+                .addOption(Option.builder()
+                        .longOpt(PERMISSION_COMPARISON)
+                        .numberOfArgs(1)
+                        .argName("strategy")
+                        .required(false)
+                        .type(PermissionComparisonStrategy.class)
+                        .desc("The strategy we should use when comparing permissions. "
+                                + "Possible values are STRICT, PERMISSION_ONLY, RELAXED, IGNORE. Optional. Default: STRICT")
                         .build());
     }
 }

--- a/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/RestoreProperties.java
+++ b/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/RestoreProperties.java
@@ -1,5 +1,6 @@
 package com.github.nagyesta.filebarj.job.cli;
 
+import com.github.nagyesta.filebarj.core.common.PermissionComparisonStrategy;
 import com.github.nagyesta.filebarj.core.model.BackupPath;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -23,4 +24,5 @@ public class RestoreProperties extends BackupFileProperties {
     private final boolean deleteFilesNotInBackup;
     private final long pointInTimeEpochSeconds;
     private final BackupPath includedPath;
+    private final PermissionComparisonStrategy permissionComparisonStrategy;
 }

--- a/file-barj-job/src/main/resources/banner.txt
+++ b/file-barj-job/src/main/resources/banner.txt
@@ -1,0 +1,21 @@
+6.3                                                                                                                      6.
+6.3                                                                                                                      6.
+6.3                     j                                                                                                6.
+6.3                     j @                                                                                              6.
+6.3                 ,;;@]p&;; 4@@@@@@@@@@@@@@@@@@@@@@$@@@@@@@@N  @@@@@@@@N@@@@@@@@@@@@@@@@@@@@@@$@@@@@@@@@                6.
+6.3                 ``N     j 4R```````MR``]@&F`j@@@@]H``````]N  B```"*0@H@@@BF```@@@@hR````"*0@]@@@@@b``@                6.
+6.3                 mWN     j 4R  ]@@@@%R  ]@&  j@@@@]H  @@@@@N  $     J@H@@@M    J@@@hR       @]@@@@@b  @                6.
+6.3                 N       j 4R  `??"@@R  ]@&  j@@@@]H  ???%@N  $    ,@@H@@@      1@@hR      ]@]@@@@@b  @                6.
+6.3                 N       j 4R  ymmm@@R  ]@&  j@@@@]H  mmm@@N  $      1H@@h       @@hR     @B@]%**$@b  @                6.
+6.3                 N       j 4R  ]@@@@@R  ]@&  "**"@]H  ****]N  $      ]H@M  ]@@N  1@hR  ]p `@@]R  `"  ,%                6.
+6.3                 N       j 4Rww&@@@@@Rww&@&wwwwww@]Wwwwwww&N  Rwwwww@BHRwww@@@@Www&hRww&Rwww@]@@Wwww@B@                6.
+6.3                 N       j 4MMMMMMMMMMMMMMMMMMMMMMRMMMMMMMMM  MMMMMMMMMMMMMMMMMMMM*32wwwwwwwwwwwwwwwwwwwww              6.
+6.3               ;mMMMMMMMM@WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWMMBB5@@@@@@@@@@@@@@@@@@$3M               6.
+6.3                @5@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@3M                6.
+6.3                `%5@B@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@3M                 6.
+6.3            "WpaMW@@MK@@M@@@M@@@M@@KM@@KM@@K%@@K%@@K%@@M%@@M%@@M%@@MK@@MK@@MK@@MK@@MK@@MK@@MK@@M@@@MDJaMwJaF          6.
+6.3               ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙  ˙            6.
+6.3                                        The easiest way to back up with a barge!                                      6.
+6.3                                                                                                                      6.
+6.3                                                                                                                      6.7
+


### PR DESCRIPTION
__Issue:__ #94

### Description
<!-- A short summary of changes -->

- Adds new command line options to --restore command to let the user select permission evaluation strategy
- Implements a verification step during backup, to warn the user about potential file name case-insensitivity issues
- Updates tests
- Adds app banner
- Updates readme

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
