### PR TITLE
Add new command to delete selected backup increments safely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ out/
 
 ### VS Code ###
 */.vscode/
+
+file-barj.log

--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ File BaRJ comes with the following features
 - Duplicate handling (storing duplicates of the same file only once)
 - Deletes left-over files from the restore directory (if they had been in scope for the backup)
 - Merge previous backup increments
+- Delete selected backup increments
 
 ### Planned features
 
-- Delete selected backup increments
 - UI for convenient configuration
+- Rotate encryption keys
+  - Shallow (only rotate KEK)
+  - Deep (rotate DEKs as well)
 
 ## Modules
 

--- a/file-barj-core/README.md
+++ b/file-barj-core/README.md
@@ -113,6 +113,20 @@ controller.inspectIncrements(System.out);
 controller.inspectContent(Long.MAX_VALUE, outputFile);
 ```
 
+### Deleting the increments of an archive
+
+```java
+//configuring the deletion job
+final var backupDir = Path.of("/backup/directory");
+final var outputFile = Path.of("/backup/directory");
+final var controller = new IncrementDeletionController(backupDir, "file-prefix", null);
+
+//Delete all backup increments:
+// - starting with the one created at 123456
+// - until (exclusive) the next full backup
+controller.deleteIncrementsUntilNextFullBackupAfter(123456L);
+```
+
 ## Further reading
 
 Please read more about the BaRJ backup jobs [here](https://github.com/nagyesta/file-barj/wiki/Backup-job-configuration-tips).

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/ManifestManager.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/ManifestManager.java
@@ -110,5 +110,17 @@ public interface ManifestManager {
      * @param job the job configuration
      * @return the manifests which can act as previous increments of the provided job
      */
-    SortedMap<Integer, BackupIncrementManifest> loadPreviousManifestsForBackup(BackupJobConfiguration job);
+    SortedMap<Integer, BackupIncrementManifest> loadPreviousManifestsForBackup(
+            @NonNull BackupJobConfiguration job);
+
+    /**
+     * Deletes all files of the backup increment represented by the provided manifest from the
+     * backup directory.
+     *
+     * @param backupDirectory the backup directory
+     * @param manifest        the manifest
+     */
+    void deleteIncrement(
+            @NonNull Path backupDirectory,
+            @NonNull BackupIncrementManifest manifest);
 }

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/delete/IncrementDeletionController.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/delete/IncrementDeletionController.java
@@ -1,0 +1,67 @@
+package com.github.nagyesta.filebarj.core.delete;
+
+import com.github.nagyesta.filebarj.core.common.ManifestManager;
+import com.github.nagyesta.filebarj.core.common.ManifestManagerImpl;
+import com.github.nagyesta.filebarj.core.model.BackupIncrementManifest;
+import com.github.nagyesta.filebarj.core.model.enums.BackupType;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.security.PrivateKey;
+import java.util.Comparator;
+import java.util.SortedMap;
+
+/**
+ * Controller for the backup increment deletion task.
+ */
+@Slf4j
+public class IncrementDeletionController {
+
+    private final SortedMap<Long, BackupIncrementManifest> manifests;
+    private final @NonNull Path backupDirectory;
+    private final ManifestManager manifestManager;
+
+    /**
+     * Creates a new instance and initializes it for the specified job.
+     *
+     * @param backupDirectory the directory where the backup files are located
+     * @param fileNamePrefix  the prefix of the backup file names
+     * @param kek             The key encryption key we want to use to decrypt the files (optional).
+     *                        If null, no decryption will be performed.
+     */
+    public IncrementDeletionController(
+            @NonNull final Path backupDirectory,
+            @NonNull final String fileNamePrefix,
+            @Nullable final PrivateKey kek) {
+        this.manifestManager = new ManifestManagerImpl();
+        this.backupDirectory = backupDirectory;
+        this.manifests = this.manifestManager.loadAll(this.backupDirectory, fileNamePrefix, kek);
+    }
+
+    /**
+     * Deletes the incremental backups which were created after the specified time until the next
+     * full backup.
+     *
+     * @param startingWithEpochSeconds the start time of the first deleted increment
+     */
+    public void deleteIncrementsUntilNextFullBackupAfter(final long startingWithEpochSeconds) {
+        final var incrementsStartingWithThreshold = this.manifests.values().stream()
+                .sorted(Comparator.comparing(BackupIncrementManifest::getStartTimeUtcEpochSeconds))
+                .filter(manifest -> manifest.getStartTimeUtcEpochSeconds() >= startingWithEpochSeconds)
+                .toList();
+        if (incrementsStartingWithThreshold.isEmpty()) {
+            throw new IllegalArgumentException("No backups found after: " + startingWithEpochSeconds);
+        }
+        if (incrementsStartingWithThreshold.get(0).getStartTimeUtcEpochSeconds() != startingWithEpochSeconds) {
+            throw new IllegalArgumentException("Unable to find backup which started at: " + startingWithEpochSeconds);
+        }
+        for (final var current : incrementsStartingWithThreshold) {
+            if (current.getStartTimeUtcEpochSeconds() > startingWithEpochSeconds && current.getBackupType() == BackupType.FULL) {
+                break;
+            }
+            manifestManager.deleteIncrement(backupDirectory, current);
+        }
+    }
+}

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/common/ManifestManagerImplTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/common/ManifestManagerImplTest.java
@@ -383,4 +383,42 @@ class ManifestManagerImplTest extends TempFileAwareTest {
 
         //then + exception
     }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testDeleteIncrementShouldThrowExceptionWhenCalledWithNullManifest() {
+        //given
+        final var underTest = new ManifestManagerImpl();
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.deleteIncrement(Path.of("destination"), null));
+
+        //then + exception
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testDeleteIncrementShouldThrowExceptionWhenCalledWithNullDestination() {
+        //given
+        final var underTest = new ManifestManagerImpl();
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> underTest.deleteIncrement(null, mock(BackupIncrementManifest.class)));
+
+        //then + exception
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testLoadPreviousManifestsForBackupShouldThrowExceptionWhenCalledWithNull() {
+        //given
+        final var underTest = new ManifestManagerImpl();
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> underTest.loadPreviousManifestsForBackup(null));
+
+        //then + exception
+    }
 }

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/delete/IncrementDeletionControllerTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/delete/IncrementDeletionControllerTest.java
@@ -1,0 +1,126 @@
+package com.github.nagyesta.filebarj.core.delete;
+
+import com.github.nagyesta.filebarj.core.TempFileAwareTest;
+import com.github.nagyesta.filebarj.core.backup.pipeline.BackupController;
+import com.github.nagyesta.filebarj.core.config.BackupJobConfiguration;
+import com.github.nagyesta.filebarj.core.config.BackupSource;
+import com.github.nagyesta.filebarj.core.config.enums.CompressionAlgorithm;
+import com.github.nagyesta.filebarj.core.config.enums.DuplicateHandlingStrategy;
+import com.github.nagyesta.filebarj.core.config.enums.HashAlgorithm;
+import com.github.nagyesta.filebarj.core.model.BackupPath;
+import com.github.nagyesta.filebarj.core.model.enums.BackupType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class IncrementDeletionControllerTest extends TempFileAwareTest {
+    private static final long ONE_SECOND = 1000L;
+
+    @SuppressWarnings({"checkstyle:MagicNumber", "MagicNumber"})
+    public Stream<Arguments> validParameterProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(1, 0, 0, 0))
+                .add(Arguments.of(2, 1, 3, 1))
+                .add(Arguments.of(5, 4, 12, 4))
+                .add(Arguments.of(5, 0, 0, 0))
+                .add(Arguments.of(5, 1, 3, 1))
+                .build();
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalledWithNullBackupDirectory() {
+        //given
+        final var fileNamePrefix = "prefix";
+
+        //when
+        assertThrows(IllegalArgumentException.class, () -> new IncrementDeletionController(null, fileNamePrefix, null));
+
+        //then + exception
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalledWithNullPrefix() {
+        //given
+        final var backupDirectory = testDataRoot;
+
+        //when
+        assertThrows(IllegalArgumentException.class, () -> new IncrementDeletionController(backupDirectory, null, null));
+
+        //then + exception
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @ParameterizedTest
+    @MethodSource("validParameterProvider")
+    void testDeleteIncrementsShouldReturnSummariesWhenCalledWithStream(
+            final int backups, final int skip, final long expectedBackupFiles, final long expectedHistoryFiles)
+            throws IOException, InterruptedException {
+        //given
+        final var originalDirectory = testDataRoot.resolve("original");
+        final var backupDirectory = testDataRoot.resolve("backup");
+        Files.createDirectories(originalDirectory);
+        Files.writeString(originalDirectory.resolve("file1.txt"), "content");
+        final var prefix = "prefix";
+        for (var i = 0; i < backups; i++) {
+            doBackup(backupDirectory, originalDirectory, prefix);
+            Thread.sleep(ONE_SECOND);
+        }
+        final var underTest = new IncrementDeletionController(backupDirectory, prefix, null);
+        final var firstBackupStarted = Arrays.stream(Objects.requireNonNull(backupDirectory.toFile().list()))
+                .filter(child -> child.startsWith(prefix) && child.endsWith(".manifest.cargo"))
+                .sorted()
+                .skip(skip)
+                .findFirst()
+                .map(child -> child.replaceFirst(Pattern.quote(prefix + "-"), "").replaceFirst("\\..+$", ""))
+                .map(Long::parseLong)
+                .orElseThrow();
+
+        //when
+        underTest.deleteIncrementsUntilNextFullBackupAfter(firstBackupStarted);
+        Thread.sleep(ONE_SECOND);
+
+        //then
+        final var matchingBackupFiles = Arrays.stream(Objects.requireNonNull(backupDirectory.toFile().list()))
+                .filter(child -> child.startsWith(prefix))
+                .count();
+        final var matchingHistoryFiles = Arrays.stream(Objects.requireNonNull(backupDirectory.resolve(".history").toFile().list()))
+                .filter(child -> child.startsWith(prefix))
+                .count();
+        Assertions.assertEquals(expectedHistoryFiles, matchingHistoryFiles);
+        Assertions.assertEquals(expectedBackupFiles, matchingBackupFiles);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static void doBackup(
+            final Path backupDirectory,
+            final Path originalDirectory,
+            final String prefix) {
+        final var configuration = BackupJobConfiguration.builder()
+                .destinationDirectory(backupDirectory)
+                .sources(Set.of(BackupSource.builder().path(BackupPath.of(originalDirectory)).build()))
+                .backupType(BackupType.INCREMENTAL)
+                .hashAlgorithm(HashAlgorithm.SHA256)
+                .fileNamePrefix(prefix)
+                .compression(CompressionAlgorithm.NONE)
+                .duplicateStrategy(DuplicateHandlingStrategy.KEEP_ONE_PER_BACKUP)
+                .build();
+        new BackupController(configuration, false).execute(1);
+    }
+}

--- a/file-barj-job/README.md
+++ b/file-barj-job/README.md
@@ -120,6 +120,26 @@ java -jar build/libs/file-barj-job.jar \
      --at-epoch-seconds 123456
 ```
 
+### Deleting the increments of a backup
+
+This task allows the deletion of those backup increments which became obsolete. In order to keep 
+only working backups, this will remove all increments starting with the one created at the selected 
+epoch seconds time and ending before the next full backup (or deleting all if no full backup found). 
+In the example below, we want to delete the increment started at 123456 (epoch seconds) amd every
+subsequent incremental backup until the next full backup.
+
+Execute the following command (assuming that your executable is named accordingly).
+
+```commandline
+java -jar build/libs/file-barj-job.jar \
+     --delete \
+     --backup-source /backup/directory/path \
+     --prefix backup-job-file-prefix \
+     --key-store keys.p12 \
+     --key-alias alias \
+     --from-epoch-seconds 123456
+```
+
 ## Further reading
 
 Please read more about configuring the BaRJ backup jobs [here](https://github.com/nagyesta/file-barj/wiki/Backup-job-configuration-tips).

--- a/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/CliDeleteIncrementsParser.java
+++ b/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/CliDeleteIncrementsParser.java
@@ -1,0 +1,51 @@
+package com.github.nagyesta.filebarj.job.cli;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+import java.io.Console;
+import java.nio.file.Path;
+
+/**
+ * Parser class for the command line arguments of the version deletion task.
+ */
+@Slf4j
+public class CliDeleteIncrementsParser extends CliICommonBackupFileParser<DeleteIncrementsProperties> {
+
+    private static final String FROM_EPOCH_SECONDS = "from-epoch-seconds";
+
+    /**
+     * Creates a new {@link CliDeleteIncrementsParser} instance and sets the input arguments.
+     *
+     * @param args    the command line arguments
+     * @param console the console we should use for password input
+     */
+    public CliDeleteIncrementsParser(final String[] args, final Console console) {
+        super(Task.DELETE_INCREMENTS,  args, commandLine -> {
+            final var prefix = commandLine.getOptionValue(PREFIX);
+            final var keyProperties = parseKeyProperties(console, commandLine);
+            final var backupSource = Path.of(commandLine.getOptionValue(BACKUP_SOURCE)).toAbsolutePath();
+            final var fromTime = Long.parseLong(commandLine.getOptionValue(FROM_EPOCH_SECONDS));
+            return DeleteIncrementsProperties.builder()
+                    .keyProperties(keyProperties)
+                    .backupSource(backupSource)
+                    .prefix(prefix)
+                    .afterEpochSeconds(fromTime)
+                    .build();
+        });
+    }
+
+    @Override
+    protected Options createOptions() {
+        return super.createOptions()
+                .addOption(Option.builder()
+                        .longOpt(FROM_EPOCH_SECONDS)
+                        .numberOfArgs(1)
+                        .argName("epoch_seconds")
+                        .required(true)
+                        .type(Long.class)
+                        .desc("The date and time using UTC epoch seconds identifying the first increment we want to delete.")
+                        .build());
+    }
+}

--- a/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/CliTaskParser.java
+++ b/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/CliTaskParser.java
@@ -44,7 +44,10 @@ public class CliTaskParser extends GenericCliParser<Task> {
                         .desc("Inspects the available backup increments of a backup.").build())
                 .addOption(Option.builder()
                         .longOpt(Task.INSPECT_INCREMENTS.getCommand())
-                        .desc("Inspects the contents of a backup increment.").build());
+                        .desc("Inspects the contents of a backup increment.").build())
+                .addOption(Option.builder()
+                        .longOpt(Task.DELETE_INCREMENTS.getCommand())
+                        .desc("Deletes the backup increments starting from a given time until the next full backup.").build());
         group.setRequired(true);
         return new Options().addOptionGroup(group);
     }

--- a/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/DeleteIncrementsProperties.java
+++ b/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/DeleteIncrementsProperties.java
@@ -1,0 +1,17 @@
+package com.github.nagyesta.filebarj.job.cli;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * The parsed command line arguments of a version deletion task.
+ */
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class DeleteIncrementsProperties extends BackupFileProperties {
+
+    private final long afterEpochSeconds;
+}
+

--- a/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/Task.java
+++ b/file-barj-job/src/main/java/com/github/nagyesta/filebarj/job/cli/Task.java
@@ -31,7 +31,11 @@ public enum Task {
     /**
      * Listing the contents of a backup increment.
      */
-    INSPECT_CONTENT("inspect-content");
+    INSPECT_CONTENT("inspect-content"),
+    /**
+     * Deleting the increments of a backup.
+     */
+    DELETE_INCREMENTS("delete");
 
     private final String command;
 

--- a/file-barj-job/src/test/java/com/github/nagyesta/filebarj/job/ControllerIntegrationTest.java
+++ b/file-barj-job/src/test/java/com/github/nagyesta/filebarj/job/ControllerIntegrationTest.java
@@ -188,5 +188,23 @@ class ControllerIntegrationTest extends TempFileAwareTest {
                 "Incremental backup manifest should not exist");
         Assertions.assertTrue(Files.exists(backupDirectory.resolve(prefix + "-" + start + "-" + end + ".manifest.cargo")),
                 "Merged backup manifest should exist");
+
+        //given we inspect the versions
+        final var deleteIncrementsArgs = new String[]{
+                "--delete",
+                "--backup-source", backupDirectory.toString(),
+                "--prefix", prefix,
+                "--key-store", keyStore.toString(),
+                "--key-alias", alias,
+                "--from-epoch-seconds", end + ""
+        };
+
+        //when inspect increments is executed
+        new Controller(deleteIncrementsArgs, console).run();
+        Thread.sleep(A_SECOND);
+
+        //then the merged manifest no longer exists
+        Assertions.assertFalse(Files.exists(backupDirectory.resolve(prefix + "-" + start + "-" + end + ".manifest.cargo")),
+                "Merged backup manifest should no longer exist");
     }
 }

--- a/file-barj-job/src/test/java/com/github/nagyesta/filebarj/job/ControllerTest.java
+++ b/file-barj-job/src/test/java/com/github/nagyesta/filebarj/job/ControllerTest.java
@@ -128,4 +128,30 @@ class ControllerTest {
         //then
         verify(underTest).doInspectIncrements(any());
     }
+
+    @Test
+    void testDeleteIncrementsShouldBeCalledWhenRequiredRestoreParametersArePassed() throws Exception {
+        //given
+        final var prefix = "prefix";
+        final var backup = Path.of("backup-dir");
+        final var store = Path.of("key-store.p12");
+        final var password = new char[]{'a', 'b', 'c'};
+        final var args = new String[]{
+                "--delete",
+                "--backup-source", backup.toString(),
+                "--prefix", prefix,
+                "--key-store", store.toString(),
+                "--from-epoch-seconds", Long.MAX_VALUE + ""
+        };
+        final var console = mock(Console.class);
+        when(console.readPassword(anyString())).thenReturn(password);
+        final var underTest = spy(new Controller(args, console));
+        doNothing().when(underTest).doDeleteIncrements(any());
+
+        //when
+        underTest.run();
+
+        //then
+        verify(underTest).doDeleteIncrements(any());
+    }
 }


### PR DESCRIPTION
__Issue:__ #190

### Description
<!-- A short summary of changes -->

- Adds new command to delete selected backup increments
- Implements parser and properties for the new command
- Moves increment deletion logic to ManifestManager to make it reusable
- Implements new controller to take care of increment deletions
- Adds new tests
- Updates documentation

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
