### PR TITLE
fix: Symbolic links to folders are treated as folders in the backup directory

### DIFF
--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/BackupSource.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/BackupSource.java
@@ -3,40 +3,44 @@ package com.github.nagyesta.filebarj.core.config;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.nagyesta.filebarj.core.model.BackupPath;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NonNull;
-import lombok.extern.jackson.Jacksonized;
+import lombok.*;
 import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * Represents a backup source root. Can match a file or directory.
  */
-@Data
-@Builder
-@Jacksonized
+@JsonDeserialize(builder = BackupSource.BackupSourceBuilder.class)
+@EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BackupSource {
     /**
      * Universal pattern including all files.
      */
-    private static final String INCLUDE_ALL_FILES = "**";
+    private static final Set<String> INCLUDE_ALL_FILES = Set.of("**");
+    /**
+     * Universal pattern not excluding any files.
+     */
+    private static final Set<String> EXCLUDE_NO_FILES = Set.of();
     /**
      * The path we want to back up. Can be file or directory.
      */
+    @Getter
     @JsonProperty("path")
     private final @Valid
     @NonNull BackupPath path;
@@ -44,14 +48,44 @@ public class BackupSource {
      * Optional include patterns for filtering the contents. Uses {@link java.nio.file.PathMatcher}
      * with "glob" syntax relative to the value of the path field.
      */
+    @Getter
     @JsonProperty("include_patterns")
     private final Set<@NotNull @NotBlank String> includePatterns;
     /**
      * Optional exclude patterns for filtering the contents. Uses {@link java.nio.file.PathMatcher}
      * with "glob" syntax relative to the value of the path field.
      */
+    @Getter
     @JsonProperty("exclude_patterns")
     private final Set<@NotNull @NotBlank String> excludePatterns;
+
+    @JsonIgnore
+    @EqualsAndHashCode.Exclude
+    private final boolean shouldIgnorePatterns;
+
+    @JsonIgnore
+    @EqualsAndHashCode.Exclude
+    private final Set<String> preprocessedIncludePatterns;
+
+    @JsonIgnore
+    @EqualsAndHashCode.Exclude
+    private final Set<String> preprocessedExcludePatterns;
+
+    BackupSource(
+            final @Valid @NonNull BackupPath path,
+            final Set<@NotNull @NotBlank String> includePatterns,
+            final Set<@NotNull @NotBlank String> excludePatterns) {
+        this.path = path;
+        this.includePatterns = Optional.ofNullable(includePatterns).map(Set::copyOf).orElse(Collections.emptySet());
+        this.shouldIgnorePatterns = shouldIgnorePatternsDueToPathType(path, includePatterns, excludePatterns);
+        this.preprocessedIncludePatterns = preprocessPatterns(coalescePatterns(includePatterns, INCLUDE_ALL_FILES));
+        this.excludePatterns = Optional.ofNullable(excludePatterns).map(Set::copyOf).orElse(Collections.emptySet());
+        this.preprocessedExcludePatterns = preprocessPatterns(coalescePatterns(excludePatterns, EXCLUDE_NO_FILES));
+    }
+
+    public static BackupSourceBuilder builder() {
+        return new BackupSourceBuilder();
+    }
 
     /**
      * Lists the matching {@link Path} entries.
@@ -71,12 +105,8 @@ public class BackupSource {
 
     @Override
     public String toString() {
-        final var includes = Optional.ofNullable(includePatterns)
-                .filter(v -> !v.isEmpty())
-                .orElse(Set.of(INCLUDE_ALL_FILES));
-        final var excludes = Optional.ofNullable(excludePatterns)
-                .filter(v -> !v.isEmpty())
-                .orElse(Set.of());
+        final var includes = coalescePatterns(includePatterns, INCLUDE_ALL_FILES);
+        final var excludes = coalescePatterns(excludePatterns, EXCLUDE_NO_FILES);
         return "BackupSource{path=" + path + ", include=" + includes + ", exclude=" + excludes + "}";
     }
 
@@ -93,7 +123,7 @@ public class BackupSource {
     private Stream<Path> listFilesRecursive(final Path fromRoot) {
         if (!fromRoot.toFile().exists()) {
             return Stream.empty();
-        } else if (!Files.isDirectory(fromRoot) || hasNoChildren(fromRoot)) {
+        } else if (!Files.isDirectory(fromRoot, LinkOption.NOFOLLOW_LINKS) || hasNoChildren(fromRoot)) {
             return Stream.of(fromRoot);
         } else {
             return Optional.ofNullable(fromRoot.toFile().listFiles())
@@ -112,32 +142,36 @@ public class BackupSource {
     }
 
     private boolean includePatternsDoMatch(final Path toFilter) {
-        if (!path.toFile().isDirectory()) {
-            assertHasNoPatterns(includePatterns, "Include");
+        if (shouldIgnorePatterns) {
             return true;
         }
         final var fileSystem = FileSystems.getDefault();
-        return Optional.ofNullable(includePatterns)
-                .filter(v -> !v.isEmpty())
-                .orElse(Set.of(INCLUDE_ALL_FILES))
-                .stream()
-                .map(this::translatePattern)
+        return preprocessedIncludePatterns.stream()
                 .map(fileSystem::getPathMatcher)
                 .anyMatch(matcher -> matcher.matches(toFilter.toAbsolutePath()));
     }
 
     private boolean excludePatternsDoNotMatch(final Path toFilter) {
-        if (!path.toFile().isDirectory()) {
-            assertHasNoPatterns(excludePatterns, "Exclude");
+        if (shouldIgnorePatterns) {
             return true;
         }
         final var fileSystem = FileSystems.getDefault();
-        return Optional.ofNullable(excludePatterns)
-                .orElse(Set.of())
-                .stream()
-                .map(this::translatePattern)
+        return preprocessedExcludePatterns.stream()
                 .map(fileSystem::getPathMatcher)
                 .noneMatch(matcher -> matcher.matches(toFilter.toAbsolutePath()));
+    }
+
+    private boolean shouldIgnorePatternsDueToPathType(
+            final BackupPath rootPath,
+            final Set<String> includePatterns,
+            final Set<String> excludePatterns) {
+        //if the file does not exist, do not care about the type, it does not matter
+        if (Files.exists(rootPath.toOsPath()) && !Files.isDirectory(rootPath.toOsPath(), LinkOption.NOFOLLOW_LINKS)) {
+            assertHasNoPatterns(includePatterns, "Include");
+            assertHasNoPatterns(excludePatterns, "Exclude");
+            return true;
+        }
+        return false;
     }
 
     private void assertHasNoPatterns(
@@ -150,6 +184,20 @@ public class BackupSource {
 
     }
 
+    private Set<String> coalescePatterns(
+            final Set<String> patterns,
+            final Set<String> defaultValue) {
+        return Optional.ofNullable(patterns)
+                .filter(set -> !set.isEmpty())
+                .orElse(defaultValue);
+    }
+
+    private SortedSet<String> preprocessPatterns(final Set<String> patterns) {
+        return Collections.unmodifiableSortedSet(patterns.stream()
+                .map(this::translatePattern)
+                .collect(Collectors.toCollection(TreeSet::new)));
+    }
+
     private String translatePattern(final String pattern) {
         //must use OS path to avoid issues with Windows paths
         return ("glob:" + FilenameUtils.normalizeNoEndSeparator(path.toOsPath().toString()) + File.separator + pattern)
@@ -157,4 +205,34 @@ public class BackupSource {
                 .replaceAll(Pattern.quote("\\"), "/");
     }
 
+    @EqualsAndHashCode
+    @NoArgsConstructor(access = AccessLevel.PACKAGE)
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+    public static class BackupSourceBuilder {
+        private BackupPath path;
+        private Set<String> includePatterns;
+        private Set<String> excludePatterns;
+
+        @JsonProperty("path")
+        public BackupSourceBuilder path(final @Valid @NonNull BackupPath path) {
+            this.path = path;
+            return this;
+        }
+
+        @JsonProperty("include_patterns")
+        public BackupSourceBuilder includePatterns(final Set<@NotNull @NotBlank String> includePatterns) {
+            this.includePatterns = includePatterns;
+            return this;
+        }
+
+        @JsonProperty("exclude_patterns")
+        public BackupSourceBuilder excludePatterns(final Set<@NotNull @NotBlank String> excludePatterns) {
+            this.excludePatterns = excludePatterns;
+            return this;
+        }
+
+        public BackupSource build() {
+            return new BackupSource(this.path, this.includePatterns, this.excludePatterns);
+        }
+    }
 }

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/BackupJobConfigurationTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/BackupJobConfigurationTest.java
@@ -269,7 +269,7 @@ class BackupJobConfigurationTest extends TempFileAwareTest {
                 .fileNamePrefix("backup-")
                 .chunkSizeMebibyte(1)
                 .sources(Set.of(BackupSource.builder()
-                        .path(BackupPath.of(testDataRoot, "visible-file1.txt"))
+                        .path(BackupPath.of(testDataRoot))
                         .includePatterns(Set.of("")).build()))
                 .build();
 
@@ -298,7 +298,7 @@ class BackupJobConfigurationTest extends TempFileAwareTest {
                 .fileNamePrefix("backup-")
                 .chunkSizeMebibyte(1)
                 .sources(Set.of(BackupSource.builder()
-                        .path(BackupPath.of(testDataRoot, "visible-file1.txt"))
+                        .path(BackupPath.of(testDataRoot))
                         .excludePatterns(Set.of("")).build()))
                 .build();
 

--- a/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/BackupSourceTest.java
+++ b/file-barj-core/src/test/java/com/github/nagyesta/filebarj/core/config/BackupSourceTest.java
@@ -189,31 +189,29 @@ class BackupSourceTest extends TempFileAwareTest {
     }
 
     @Test
-    void testListMatchingFilePathsShouldThrowExceptionWhenIncludePatternsAreSuppliedAndRootIsRegularFile() {
+    void testBuildShouldThrowExceptionWhenIncludePatternsAreSuppliedAndRootIsRegularFile() {
         //given
         final var expectedFile = BackupPath.of(testDataRoot, "visible-file1.txt");
         final var underTest = BackupSource.builder()
                 .path(expectedFile)
-                .includePatterns(Set.of("**.txt"))
-                .build();
+                .includePatterns(Set.of("**.txt"));
 
         //when
-        Assertions.assertThrows(IllegalArgumentException.class, underTest::listMatchingFilePaths);
+        Assertions.assertThrows(IllegalArgumentException.class, underTest::build);
 
         //then + exception
     }
 
     @Test
-    void testListMatchingFilePathsShouldThrowExceptionWhenExcludePatternsAreSuppliedAndRootIsRegularFile() {
+    void testBuildShouldThrowExceptionWhenExcludePatternsAreSuppliedAndRootIsRegularFile() {
         //given
         final var expectedFile = BackupPath.of(testDataRoot, "visible-file1.txt");
         final var underTest = BackupSource.builder()
                 .path(expectedFile)
-                .excludePatterns(Set.of("**.txt"))
-                .build();
+                .excludePatterns(Set.of("**.txt"));
 
         //when
-        Assertions.assertThrows(IllegalArgumentException.class, underTest::listMatchingFilePaths);
+        Assertions.assertThrows(IllegalArgumentException.class, underTest::build);
 
         //then + exception
     }


### PR DESCRIPTION
**Issue:** #527

### Description

<!-- A short summary of changes -->

- Set backup source to do not follow links
- Pre-process file patterns in the backup source to speed up filtering
- Update affected tests

### Entry point

<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: `{major}`, `{minor}` or `{patch}`
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

- <!-- Any additional remarks you may have. -->
