### PR TITLE
feat: Change file path scanning to hide data store behind an interface

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,6 @@ buildscript {
         set("ossrhSnapshotRepoUrl", "https://central.sonatype.com/repository/maven-snapshots/")
         set("sonarOrganization", "nagyesta")
         set("sonarProjectKey", "nagyesta_file-barj")
-        set("sonarHostUrl", "https://sonarcloud.io/")
     }
 }
 
@@ -87,7 +86,6 @@ sonar {
         //no jacoco report because there are no sources
         property("sonar.organization", rootProject.extra.get("sonarOrganization") as String)
         property("sonar.projectKey", rootProject.extra.get("sonarProjectKey") as String)
-        property("sonar.host.url", rootProject.extra.get("sonarHostUrl") as String)
     }
 }
 
@@ -121,7 +119,6 @@ subprojects {
             property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/report.xml").get().asFile.path)
             property("sonar.organization", rootProject.extra.get("sonarOrganization") as String)
             property("sonar.projectKey", rootProject.extra.get("sonarProjectKey") as String)
-            property("sonar.host.url", rootProject.extra.get("sonarHostUrl") as String)
         }
     }
 

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/BackupSourceScanner.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/common/BackupSourceScanner.java
@@ -1,0 +1,213 @@
+package com.github.nagyesta.filebarj.core.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nagyesta.filebarj.core.config.BackupSource;
+import com.github.nagyesta.filebarj.core.model.BackupPath;
+import com.github.nagyesta.filebarj.core.persistence.FileSetRepository;
+import com.github.nagyesta.filebarj.core.persistence.entities.FileSetId;
+import lombok.NonNull;
+import org.apache.commons.io.FilenameUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Scans the files present in a backup source root.
+ */
+public class BackupSourceScanner {
+    /**
+     * Universal pattern including all files.
+     */
+    private static final Set<String> INCLUDE_ALL_FILES = Set.of("**");
+    /**
+     * Universal pattern not excluding any files.
+     */
+    private static final Set<String> EXCLUDE_NO_FILES = Set.of();
+    private static final String GLOB_WITH_NO_WILDCARDS = "glob:[^*?\\[]+";
+
+    private final FileSetRepository fileSetRepository;
+    private final BackupSource backupSource;
+    private final Path backupSourceOsPath;
+    private final SortedSet<String> includePatterns;
+    private final SortedSet<String> excludePatterns;
+    private final SortedSet<String> concreteExcludePatterns;
+    private final boolean shouldUsePatterns;
+
+    public BackupSourceScanner(
+            final @NonNull FileSetRepository fileSetRepository,
+            final @NonNull BackupSource backupSource) {
+        this.fileSetRepository = fileSetRepository;
+        this.backupSource = backupSource;
+        this.backupSourceOsPath = backupSource.getPath().toOsPath();
+        final var originalIncludes = backupSource.getIncludePatterns();
+        final var originalExcludes = backupSource.getExcludePatterns();
+        this.shouldUsePatterns = pathTypeCanUsePatterns(backupSource.getPath(), originalIncludes, originalExcludes);
+        this.includePatterns = preProcessPatterns(coalescePatterns(originalIncludes, INCLUDE_ALL_FILES));
+        this.excludePatterns = preProcessPatterns(coalescePatterns(originalExcludes, EXCLUDE_NO_FILES));
+        this.concreteExcludePatterns = preProcessConcretePatterns(excludePatterns);
+    }
+
+    /**
+     * Lists the matching {@link Path} entries.
+     *
+     * @param resultFileSetId the Id of the file se where we should collect the results
+     */
+    @JsonIgnore
+    public void listMatchingFilePaths(final @NonNull FileSetId resultFileSetId) {
+        try (var tempFileSetId = fileSetRepository.createFileSet()) {
+            var current = Optional.of(backupSourceOsPath);
+            var parentDirsFromBackupSource = List.<Path>of();
+            while (current.isPresent()) {
+                final var currentPath = current.get();
+                if (!parentDirsFromBackupSource.contains(currentPath.getParent())) {
+                    parentDirsFromBackupSource = findParentsFromBackupSource(currentPath);
+                }
+                listRemainingFiles(currentPath, parentDirsFromBackupSource, resultFileSetId, tempFileSetId);
+                current = fileSetRepository.takeFirst(tempFileSetId);
+            }
+        }
+    }
+
+    private List<Path> findParentsFromBackupSource(final @NotNull Path path) {
+        final var parents = new ArrayList<>(List.of(backupSourceOsPath));
+        var current = path.getParent();
+        while (current.startsWith(backupSourceOsPath)) {
+            parents.add(current);
+            current = current.getParent();
+        }
+        return parents;
+    }
+
+    private void listRemainingFiles(
+            final @NotNull Path currentPath,
+            final @NotNull List<Path> parentDirsFromBackupSource,
+            final @NotNull FileSetId sourceFileSetIt,
+            final @NotNull FileSetId tempFileSetId) {
+        if (!currentPath.toFile().exists()) {
+            return;
+        }
+        if (shouldIgnoreByConcretePattern(currentPath)) {
+            return;
+        }
+        if (!Files.isDirectory(currentPath, LinkOption.NOFOLLOW_LINKS)) {
+            if (shouldIgnoreFileByPatterns(currentPath)) {
+                return;
+            }
+            //add all parents if they are not saved yet
+            fileSetRepository.appendTo(sourceFileSetIt, parentDirsFromBackupSource);
+            fileSetRepository.appendTo(sourceFileSetIt, currentPath);
+        } else {
+            if (isCurrentDirectoryInSourceSetByPatterns(currentPath)) {
+                //always add directories if the include patterns match and the exclude patterns do not match
+                fileSetRepository.appendTo(sourceFileSetIt, parentDirsFromBackupSource);
+                fileSetRepository.appendTo(sourceFileSetIt, currentPath);
+            }
+            if (hasChildren(currentPath)) {
+                Optional.ofNullable(currentPath.toFile().listFiles())
+                        .stream()
+                        .flatMap(Arrays::stream)
+                        .map(File::toPath)
+                        .forEach((Path child) -> fileSetRepository.appendTo(tempFileSetId, child));
+            }
+        }
+    }
+
+    private boolean isCurrentDirectoryInSourceSetByPatterns(final @NotNull Path currentPath) {
+        return shouldUsePatterns && includePatternsMatch(currentPath) && !excludePatternsMatch(currentPath);
+    }
+
+    private boolean shouldIgnoreByConcretePattern(final @NotNull Path currentPath) {
+        return shouldUsePatterns && concreteExcludePatternsMatch(currentPath);
+    }
+
+    private boolean shouldIgnoreFileByPatterns(final @NotNull Path currentPath) {
+        return shouldUsePatterns && (!includePatternsMatch(currentPath) || excludePatternsMatch(currentPath));
+    }
+
+    private boolean hasChildren(final @NotNull Path dirPath) {
+        return Optional.ofNullable(dirPath.toFile().list())
+                .filter(array -> array.length > 0)
+                .isPresent();
+    }
+
+    private boolean includePatternsMatch(final @NotNull Path toFilter) {
+        final var fileSystem = FileSystems.getDefault();
+        return includePatterns.stream()
+                .map(fileSystem::getPathMatcher)
+                .anyMatch(matcher -> matcher.matches(toFilter.toAbsolutePath()));
+    }
+
+    private boolean excludePatternsMatch(final @NotNull Path toFilter) {
+        return excludePatternsMatch(excludePatterns, toFilter);
+    }
+
+    private boolean concreteExcludePatternsMatch(final @NotNull Path toFilter) {
+        return excludePatternsMatch(concreteExcludePatterns, toFilter);
+    }
+
+    private boolean excludePatternsMatch(
+            final @NotNull SortedSet<String> patterns,
+            final @NotNull Path toFilter) {
+        final var fileSystem = FileSystems.getDefault();
+        return patterns.stream()
+                .map(fileSystem::getPathMatcher)
+                .anyMatch(matcher -> matcher.matches(toFilter.toAbsolutePath()));
+    }
+
+    private boolean pathTypeCanUsePatterns(
+            final @NotNull BackupPath rootPath,
+            final @NotNull Set<String> includePatterns,
+            final @NotNull Set<String> excludePatterns) {
+        //if the file does not exist, do not care about the type, it does not matter
+        if (Files.exists(rootPath.toOsPath()) && !Files.isDirectory(rootPath.toOsPath(), LinkOption.NOFOLLOW_LINKS)) {
+            assertHasNoPatterns(includePatterns, "Include");
+            assertHasNoPatterns(excludePatterns, "Exclude");
+            return false;
+        }
+        return true;
+    }
+
+    private void assertHasNoPatterns(
+            final @Nullable Set<String> patterns,
+            final @NotNull String prefix) {
+        if (!Optional.ofNullable(patterns).orElse(Collections.emptySet()).isEmpty()) {
+            throw new IllegalArgumentException(
+                    prefix + " patterns cannot be defined when the backup source is not a directory: " + backupSource.getPath());
+        }
+    }
+
+    private @NotNull Set<String> coalescePatterns(
+            final @Nullable Set<String> patterns,
+            final @NotNull Set<String> defaultValue) {
+        return Optional.ofNullable(patterns)
+                .filter(set -> !set.isEmpty())
+                .orElse(defaultValue);
+    }
+
+    private @NotNull SortedSet<String> preProcessPatterns(final @NotNull Set<String> patterns) {
+        return Collections.unmodifiableSortedSet(patterns.stream()
+                .map(this::translatePattern)
+                .collect(Collectors.toCollection(TreeSet::new)));
+    }
+
+    private @NotNull SortedSet<String> preProcessConcretePatterns(final @NotNull SortedSet<String> patterns) {
+        return Collections.unmodifiableSortedSet(patterns.stream()
+                .filter(pattern -> pattern.matches(GLOB_WITH_NO_WILDCARDS))
+                .collect(Collectors.toCollection(TreeSet::new)));
+    }
+
+    private @NotNull String translatePattern(final @NotNull String pattern) {
+        //must use OS path to avoid issues with Windows paths
+        return ("glob:" + FilenameUtils.normalizeNoEndSeparator(backupSource.getPath().toOsPath().toString()) + File.separator + pattern)
+                //replace backslashes to let the regex conversion work later
+                .replaceAll(Pattern.quote("\\"), "/");
+    }
+}

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/BackupSource.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/config/BackupSource.java
@@ -1,6 +1,5 @@
 package com.github.nagyesta.filebarj.core.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -9,18 +8,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-import org.apache.commons.io.FilenameUtils;
 
-import java.io.File;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Represents a backup source root. Can match a file or directory.
@@ -29,14 +20,6 @@ import java.util.stream.Stream;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BackupSource {
-    /**
-     * Universal pattern including all files.
-     */
-    private static final Set<String> INCLUDE_ALL_FILES = Set.of("**");
-    /**
-     * Universal pattern not excluding any files.
-     */
-    private static final Set<String> EXCLUDE_NO_FILES = Set.of();
     /**
      * The path we want to back up. Can be file or directory.
      */
@@ -59,155 +42,27 @@ public class BackupSource {
     @JsonProperty("exclude_patterns")
     private final Set<@NotNull @NotBlank String> excludePatterns;
 
-    @JsonIgnore
-    @EqualsAndHashCode.Exclude
-    private final boolean shouldIgnorePatterns;
-
-    @JsonIgnore
-    @EqualsAndHashCode.Exclude
-    private final Set<String> preprocessedIncludePatterns;
-
-    @JsonIgnore
-    @EqualsAndHashCode.Exclude
-    private final Set<String> preprocessedExcludePatterns;
-
     BackupSource(
             final @Valid @NonNull BackupPath path,
             final Set<@NotNull @NotBlank String> includePatterns,
             final Set<@NotNull @NotBlank String> excludePatterns) {
         this.path = path;
         this.includePatterns = Optional.ofNullable(includePatterns).map(Set::copyOf).orElse(Collections.emptySet());
-        this.shouldIgnorePatterns = shouldIgnorePatternsDueToPathType(path, includePatterns, excludePatterns);
-        this.preprocessedIncludePatterns = preprocessPatterns(coalescePatterns(includePatterns, INCLUDE_ALL_FILES));
         this.excludePatterns = Optional.ofNullable(excludePatterns).map(Set::copyOf).orElse(Collections.emptySet());
-        this.preprocessedExcludePatterns = preprocessPatterns(coalescePatterns(excludePatterns, EXCLUDE_NO_FILES));
     }
 
     public static BackupSourceBuilder builder() {
         return new BackupSourceBuilder();
     }
 
-    /**
-     * Lists the matching {@link Path} entries.
-     *
-     * @return matching paths
-     */
-    @JsonIgnore
-    public List<Path> listMatchingFilePaths() {
-        return listFilesRecursive(path.toOsPath())
-                .filter(this::includePatternsDoMatch)
-                .flatMap(this::includeIntermediateDirectories)
-                .filter(this::excludePatternsDoNotMatch)
-                .distinct()
-                .sorted(Comparator.comparing(Path::toAbsolutePath))
-                .toList();
-    }
-
     @Override
     public String toString() {
-        final var includes = coalescePatterns(includePatterns, INCLUDE_ALL_FILES);
-        final var excludes = coalescePatterns(excludePatterns, EXCLUDE_NO_FILES);
-        return "BackupSource{path=" + path + ", include=" + includes + ", exclude=" + excludes + "}";
-    }
-
-    private Stream<Path> includeIntermediateDirectories(final Path aPath) {
-        final var pathAsStream = Stream.of(aPath);
-        if (aPath.toAbsolutePath().equals(path.toOsPath())) {
-            return pathAsStream;
-        } else {
-            return Stream.of(pathAsStream, includeIntermediateDirectories(aPath.getParent()))
-                    .flatMap(Function.identity());
-        }
-    }
-
-    private Stream<Path> listFilesRecursive(final Path fromRoot) {
-        if (!fromRoot.toFile().exists()) {
-            return Stream.empty();
-        } else if (!Files.isDirectory(fromRoot, LinkOption.NOFOLLOW_LINKS) || hasNoChildren(fromRoot)) {
-            return Stream.of(fromRoot);
-        } else {
-            return Optional.ofNullable(fromRoot.toFile().listFiles())
-                    .stream()
-                    .flatMap(Arrays::stream)
-                    .map(File::toPath)
-                    .flatMap(this::listFilesRecursive);
-        }
-    }
-
-    private boolean hasNoChildren(final Path dirPath) {
-        return Optional.ofNullable(dirPath.toFile().list())
-                .map(List::of)
-                .orElse(Collections.emptyList())
-                .isEmpty();
-    }
-
-    private boolean includePatternsDoMatch(final Path toFilter) {
-        if (shouldIgnorePatterns) {
-            return true;
-        }
-        final var fileSystem = FileSystems.getDefault();
-        return preprocessedIncludePatterns.stream()
-                .map(fileSystem::getPathMatcher)
-                .anyMatch(matcher -> matcher.matches(toFilter.toAbsolutePath()));
-    }
-
-    private boolean excludePatternsDoNotMatch(final Path toFilter) {
-        if (shouldIgnorePatterns) {
-            return true;
-        }
-        final var fileSystem = FileSystems.getDefault();
-        return preprocessedExcludePatterns.stream()
-                .map(fileSystem::getPathMatcher)
-                .noneMatch(matcher -> matcher.matches(toFilter.toAbsolutePath()));
-    }
-
-    private boolean shouldIgnorePatternsDueToPathType(
-            final BackupPath rootPath,
-            final Set<String> includePatterns,
-            final Set<String> excludePatterns) {
-        //if the file does not exist, do not care about the type, it does not matter
-        if (Files.exists(rootPath.toOsPath()) && !Files.isDirectory(rootPath.toOsPath(), LinkOption.NOFOLLOW_LINKS)) {
-            assertHasNoPatterns(includePatterns, "Include");
-            assertHasNoPatterns(excludePatterns, "Exclude");
-            return true;
-        }
-        return false;
-    }
-
-    private void assertHasNoPatterns(
-            final Set<String> patterns,
-            final String prefix) {
-        if (!Optional.ofNullable(patterns).orElse(Collections.emptySet()).isEmpty()) {
-            throw new IllegalArgumentException(
-                    prefix + " patterns cannot be defined when the backup source is not a directory: " + path);
-        }
-
-    }
-
-    private Set<String> coalescePatterns(
-            final Set<String> patterns,
-            final Set<String> defaultValue) {
-        return Optional.ofNullable(patterns)
-                .filter(set -> !set.isEmpty())
-                .orElse(defaultValue);
-    }
-
-    private SortedSet<String> preprocessPatterns(final Set<String> patterns) {
-        return Collections.unmodifiableSortedSet(patterns.stream()
-                .map(this::translatePattern)
-                .collect(Collectors.toCollection(TreeSet::new)));
-    }
-
-    private String translatePattern(final String pattern) {
-        //must use OS path to avoid issues with Windows paths
-        return ("glob:" + FilenameUtils.normalizeNoEndSeparator(path.toOsPath().toString()) + File.separator + pattern)
-                //replace backslashes to let the regex conversion work later
-                .replaceAll(Pattern.quote("\\"), "/");
+        return "BackupSource{path=" + path + ", include=" + includePatterns + ", exclude=" + excludePatterns + "}";
     }
 
     @EqualsAndHashCode
     @NoArgsConstructor(access = AccessLevel.PACKAGE)
-    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     public static class BackupSourceBuilder {
         private BackupPath path;
         private Set<String> includePatterns;

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/persistence/DataRepositories.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/persistence/DataRepositories.java
@@ -1,0 +1,23 @@
+package com.github.nagyesta.filebarj.core.persistence;
+
+import com.github.nagyesta.filebarj.core.persistence.inmemory.InMemoryFileSetRepository;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * The single source where all repository classes are collected.
+ */
+@Getter
+@AllArgsConstructor
+public enum DataRepositories {
+
+    /**
+     * Uses in-memory implementations for each repository.
+     */
+    @SuppressWarnings({"checkstyle:MagicNumber"})
+    IN_MEMORY(new InMemoryFileSetRepository());
+
+    @NonNull
+    private final FileSetRepository fileSetRepository;
+}

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/persistence/FileSetRepository.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/persistence/FileSetRepository.java
@@ -1,0 +1,52 @@
+package com.github.nagyesta.filebarj.core.persistence;
+
+import com.github.nagyesta.filebarj.core.persistence.entities.FileSetId;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.Consumer;
+
+public interface FileSetRepository {
+
+    /**
+     * The default page size used when not specified during looping.
+     */
+    long PAGE_SIZE = 100L;
+
+    FileSetId createFileSet();
+
+    void appendTo(FileSetId id, Path path);
+
+    void appendTo(FileSetId id, Collection<Path> paths);
+
+    Optional<Path> takeFirst(FileSetId id);
+
+    void removeFileSet(FileSetId id);
+
+    default List<Path> findAll(final FileSetId id, final long offset, final long limit) {
+        return findAll(id, offset, limit, SortOrder.ASC);
+    }
+
+    List<Path> findAll(FileSetId id, long offset, long limit, SortOrder sortOrder);
+
+    long countAll(FileSetId id);
+
+    boolean isEmpty(FileSetId id);
+
+    List<Path> detectCaseInsensitivityIssues(FileSetId id);
+
+    default void forEach(final FileSetId fileSetId, final ForkJoinPool threadPool, final Consumer<Path> consumer) {
+        forEach(fileSetId, threadPool, SortOrder.ASC, consumer);
+    }
+
+    default void forEachReverse(final FileSetId fileSetId, final ForkJoinPool threadPool, final Consumer<Path> consumer) {
+        forEach(fileSetId, threadPool, SortOrder.DESC, consumer);
+    }
+
+    void forEach(FileSetId fileSetId, ForkJoinPool threadPool, SortOrder order, Consumer<Path> consumer);
+
+}
+

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/persistence/SortOrder.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/persistence/SortOrder.java
@@ -1,0 +1,16 @@
+package com.github.nagyesta.filebarj.core.persistence;
+
+/**
+ * Defines the sort order of a persistent data set.
+ */
+public enum SortOrder {
+
+    /**
+     * Ascending.
+     */
+    ASC,
+    /**
+     * Descending.
+     */
+    DESC
+}

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/persistence/entities/FileSetId.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/persistence/entities/FileSetId.java
@@ -1,0 +1,17 @@
+package com.github.nagyesta.filebarj.core.persistence.entities;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public record FileSetId(@NotNull UUID id, @NotNull Consumer<FileSetId> closeWith) implements AutoCloseable {
+    public FileSetId(@NotNull final Consumer<FileSetId> closeWith) {
+        this(UUID.randomUUID(), closeWith);
+    }
+
+    @Override
+    public void close() {
+        closeWith.accept(this);
+    }
+}

--- a/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/persistence/inmemory/InMemoryFileSetRepository.java
+++ b/file-barj-core/src/main/java/com/github/nagyesta/filebarj/core/persistence/inmemory/InMemoryFileSetRepository.java
@@ -1,0 +1,160 @@
+package com.github.nagyesta.filebarj.core.persistence.inmemory;
+
+import com.github.nagyesta.filebarj.core.persistence.FileSetRepository;
+import com.github.nagyesta.filebarj.core.persistence.SortOrder;
+import com.github.nagyesta.filebarj.core.persistence.entities.FileSetId;
+import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+public class InMemoryFileSetRepository implements FileSetRepository {
+
+    private final Map<UUID, Queue<Path>> fileSets = new ConcurrentHashMap<>();
+    private final Map<UUID, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+    @Override
+    public FileSetId createFileSet() {
+        final var fileSetId = new FileSetId(this::removeFileSet);
+        fileSets.put(fileSetId.id(), new LinkedList<>());
+        locks.put(fileSetId.id(), new ReentrantLock());
+        return fileSetId;
+    }
+
+    @Override
+    public void appendTo(
+            final @NonNull FileSetId id,
+            final @NonNull Path path) {
+        appendTo(id, Collections.singletonList(path));
+    }
+
+    @Override
+    public void appendTo(
+            final @NonNull FileSetId id,
+            final @NonNull Collection<Path> paths) {
+        final var lock = findLockFor(id);
+        lock.lock();
+        try {
+            if (fileSets.containsKey(id.id())) {
+                final var fileSet = fileSets.get(id.id());
+                paths.forEach(path -> {
+                    if (!fileSet.contains(path)) {
+                        fileSet.add(path);
+                    }
+                });
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public Optional<Path> takeFirst(final @NonNull FileSetId id) {
+        final var lock = findLockFor(id);
+        lock.lock();
+        try {
+            final var paths = fileSets.get(id.id());
+            return Optional.ofNullable(paths.poll());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void removeFileSet(final @NonNull FileSetId id) {
+        final var lock = findLockFor(id);
+        lock.lock();
+        try {
+            fileSets.remove(id.id());
+            locks.remove(id.id());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public List<Path> findAll(
+            final @NonNull FileSetId id,
+            final long offset,
+            final long limit,
+            final @NonNull SortOrder order) {
+        final var lock = findLockFor(id);
+        lock.lock();
+        try {
+            return fileSets.get(id.id()).stream()
+                    .sorted(orderBy(order))
+                    .skip(offset)
+                    .limit(limit)
+                    .toList();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public long countAll(final @NonNull FileSetId id) {
+        final var lock = findLockFor(id);
+        lock.lock();
+        try {
+            return fileSets.get(id.id()).size();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean isEmpty(final @NonNull FileSetId id) {
+        return countAll(id) == 0L;
+    }
+
+    @Override
+    public List<Path> detectCaseInsensitivityIssues(final @NonNull FileSetId id) {
+        final var lock = findLockFor(id);
+        lock.lock();
+        try {
+            return fileSets.get(id.id()).stream()
+                    .collect(Collectors.groupingBy(path -> path.toString().toLowerCase()))
+                    .values().stream()
+                    .filter(paths -> paths.size() > 1)
+                    .flatMap(Collection::stream)
+                    .sorted()
+                    .toList();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void forEach(
+            final @NonNull FileSetId fileSetId,
+            final @NonNull ForkJoinPool threadPool,
+            final @NonNull SortOrder order,
+            final @NonNull Consumer<Path> consumer) {
+        final var countAll = countAll(fileSetId);
+        LongStream.iterate(0L, offset -> offset < countAll, offset -> offset + PAGE_SIZE)
+                .mapToObj(offset -> findAll(fileSetId, offset, PAGE_SIZE, order))
+                .forEach(paths -> threadPool.submit(() -> paths.stream().parallel().forEach(consumer)).join());
+    }
+
+    private ReentrantLock findLockFor(final @NotNull FileSetId id) {
+        final var lock = locks.get(id.id());
+        if (lock == null) {
+            throw new IllegalStateException("Failed to obtain locks for: " + id);
+        }
+        return lock;
+    }
+
+    private Comparator<Path> orderBy(final @NotNull SortOrder order) {
+        return switch (order) {
+            case ASC -> Comparator.naturalOrder();
+            case DESC -> Comparator.reverseOrder();
+        };
+    }
+}


### PR DESCRIPTION
**Issue:** #549

### Description

- Add more tests for globs
- Create file path repository
- Modify file path scanning to store all results in the repository
- Use file sets in a paginated manner (preparing for DB backed options)

### Entry point

<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: `{major}`, `{minor}` or `{patch}`
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

- <!-- Any additional remarks you may have. -->
